### PR TITLE
refactor: renamed klang to kin

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,28 +1,28 @@
 cmake_minimum_required(VERSION 3.19)
-project(klang C)
+project(kin C)
 
 # Set C standard to C11
 set(CMAKE_C_STANDARD 11)
 
 # Add executable and list source files
-add_executable(klang
-    src/main.c
+add_executable(kin
     src/lexer.c
     src/parser.c
+    src/main.c
 )
 
 # Specify include directories (if needed)
-target_include_directories(klang PRIVATE include)
+target_include_directories(kin PRIVATE include)
 
-# Add compiler-specific options if necessary (e.g., for warnings or optimizations)
+# Add compiler-specific options
 if (CMAKE_COMPILER_IS_GNUCC)
-    target_compile_options(klang PRIVATE -Wall -Wextra)
+    target_compile_options(kin PRIVATE -Wall -Wextra)
 elseif (MSVC)
-    target_compile_options(klang PRIVATE /W4)
+    target_compile_options(kin PRIVATE /W4)
 endif()
 
 # Specify output directory for the executable
 set(EXECUTABLE_OUTPUT_PATH ${CMAKE_BINARY_DIR}/bin)
 
 # Optional: Generate compile_commands.json for better IDE integration
-set(CMAKE_EXPORT_COMPILE_COMMANDS ON)
+# set(CMAKE_EXPORT_COMPILE_COMMANDS ON)

--- a/README.md
+++ b/README.md
@@ -1,8 +1,8 @@
-`klang` `Under Development` `Contributions are welcomed` `Sponsor this project`
+`Kin` `Under Development` `Contributions are welcomed` `Sponsor this project`
 
-# Klang
+# Kin
 
-Klang is a DSL (Domain Specific Language), Dynamically Typed and high-level programming language.
+Kin is a DSL (Domain Specific Language), Dynamically Typed and high-level programming language.
 It is designed to allow people `write computer programs in Kinyarwanda (Native language for Rwandans).`
 *`Our language is designed to allow people to be easly get introduced to programming`*.
 
@@ -12,8 +12,8 @@ This language is still under development and it's being written by [@pacifiquem]
 
 ## Contributing
 
-Contributions are welcomed, refer to [Contiributing.md](https://github.com/pacifiquem/klang/blob/main/contributing.md) for futher info.
+Contributions are welcomed, refer to [Contiributing.md](https://github.com/kin-lang/kin/blob/main/contributing.md) for futher info.
 
 ## License
 
-This project is under [Apache License 2.0 LICENSE](https://github.com/pacifiquem/klang/blob/main/LICENSE).
+This project is under [Apache License 2.0 LICENSE](https://github.com/kin-lang/kin/blob/main/LICENSE).

--- a/contributing.md
+++ b/contributing.md
@@ -1,11 +1,11 @@
-# Klang
+# kin-lang
 
-Klang relies on many contributors who help us to maintain or track issues, we continously `thank them` for their great work.
+Kin relies on many contributors who help us to maintain or track issues, we continously `thank them` for their great work.
 
 
 ## Issue tracking
 
-Klang team tracks issues by using Github, if you face any issue or you want to request changes please submit a new Issue and respect those templates because we will not tolerate those who violates them since they make our work too dificult. `If you don't respect Issue templates and use them unaccordingly your issue will be closed Immediately.`
+Kin team tracks issues by using Github, if you face any issue or you want to request changes please submit a new Issue and respect those templates because we will not tolerate those who violates them since they make our work too dificult. `If you don't respect Issue templates and use them unaccordingly your issue will be closed Immediately.`
 
 ## Pull Request
 
@@ -22,6 +22,6 @@ If you fix any issue or add new feature, feel free to open a pull request. It wi
 
 ## Discussions
 
-Klang uses `Github Discussions` to bring it's users together and create an engageable community.
+Kin uses `Github Discussions` to bring it's users together and create an engageable community.
 
 If you have anything to ask community please use `Github Discussion` for our main repo, there will be engineers to answer your questions.

--- a/examples/arthimetic-operators.k
+++ b/examples/arthimetic-operators.k
@@ -4,7 +4,7 @@
 
 
 
-#arthimetic operators in klang
+#arthimetic operators in kin-lang
 
 num1 = 100;
 num2 = 200;

--- a/examples/comments.k
+++ b/examples/comments.k
@@ -4,6 +4,6 @@
 
 
 
-# this is comment in klang
+# this is comment in kin-lang
 
 tangaza_amakuru `comments are ignored while parsing`;

--- a/examples/data-types.k
+++ b/examples/data-types.k
@@ -3,7 +3,7 @@
 #   LICENSE file in the root directory of this source tree.
 
 
-#data-types in klang
+#data-types in kin-lang
 
 
 umubare = 10;

--- a/examples/functions.k
+++ b/examples/functions.k
@@ -2,7 +2,7 @@
 #   This source code is licensed under the Apache License 2.0 found in the
 #   LICENSE file in the root directory of this source tree.
 
-# functions in klang
+# functions in kin-lang
 
 porogaramu_ntoya multiply_by_2(num) {
     tanga num * 2;

--- a/examples/if-statements.k
+++ b/examples/if-statements.k
@@ -3,7 +3,7 @@
 #   LICENSE file in the root directory of this source tree.
 
 
-#if-statements in klang
+#if-statements in kin-lang
 
 i = injiza_amakuru `Duhe umubare: `;
 

--- a/examples/loop-control-statements.k
+++ b/examples/loop-control-statements.k
@@ -3,7 +3,7 @@
 #   LICENSE file in the root directory of this source tree.
 
 
-#loops control statements in klang
+#loops control statements in kin-lang
 
 i = 0;
 

--- a/examples/loops.k
+++ b/examples/loops.k
@@ -2,7 +2,7 @@
 #   This source code is licensed under the Apache License 2.0 found in the
 #   LICENSE file in the root directory of this source tree.
 
-# simple loop in klang
+# simple loop in kin-lang
 
 i = 0;
 

--- a/examples/miscellaneous-operators.k
+++ b/examples/miscellaneous-operators.k
@@ -4,7 +4,7 @@
 
 
 
-# pointers in klang
+# pointers in kin-lang
 
 izina = "MURANGWA Pacifique";
 *aho_izina_ribitse = &izina;

--- a/examples/recursion.k
+++ b/examples/recursion.k
@@ -4,7 +4,7 @@
 
 
 
-#demonstrating recursion in klang
+#demonstrating recursion in kin-lang
 
 
 porogaramu_ntoya factorial(umubare) {

--- a/examples/relational-logic-operators.k
+++ b/examples/relational-logic-operators.k
@@ -25,8 +25,8 @@ niba (umubare2 < 30) {
     tangaza_amakuru `umubare2 is LESS THAN 20 `;
 }
 
-this_is_klang = sibyo;
+this_is_kin = sibyo;
 
-if(!this_is_klang) {
-    tangaza_amakuru `this language is NOT klang `;
+if(!this_is_kin) {
+    tangaza_amakuru `this language is NOT kin-lang `;
 }

--- a/examples/type-casting.k
+++ b/examples/type-casting.k
@@ -2,6 +2,8 @@
 #   This source code is licensed under the Apache License 2.0 found in the
 #   LICENSE file in the root directory of this source tree.
 
+#type-casting in kin-lang
+
 # type-casting integer -> float (<->)
 # (<->) means vice-versa
 

--- a/examples/unary-operators.k
+++ b/examples/unary-operators.k
@@ -3,7 +3,7 @@
 #   LICENSE file in the root directory of this source tree.
 
 
-# demonstrating unary operators
+# demonstrating unary operators in kin
 
 num1 = 10;
 num2 = 2;

--- a/examples/user-input.k
+++ b/examples/user-input.k
@@ -3,7 +3,7 @@
 #   LICENSE file in the root directory of this source tree.
 
 
-# getting user's input from keyboard
+# getting user's input from keyboard - kin-lang
 
 num1 = injiza_amakuru `Enter num1:`;
 num2 = injiza_amakuru `Enter num2:`;

--- a/src/headers/exit-codes.h
+++ b/src/headers/exit-codes.h
@@ -1,7 +1,7 @@
-#ifndef KLANG_INTERPRETER_EXIT_CODES_H
-#define KLANG_INTERPRETER_EXIT_CODES_H
+#ifndef KIN_INTERPRETER_EXIT_CODES_H
+#define KIN_INTERPRETER_EXIT_CODES_H
 
-// Exit codes for the klang interpreter
+// Exit codes for the kin interpreter
 #define EXIT_SUCCESS 0                  // Successful execution
 #define EXIT_FAILURE 1                 // program exited with an error
 #define EXIT_SYNTAX_ERROR 2             // Syntax error

--- a/src/headers/lexer.h
+++ b/src/headers/lexer.h
@@ -1,6 +1,6 @@
 //> Scanning on Demand scanner-h
-#ifndef klang_lexer_h
-#define klang_lexer_h
+#ifndef KIN_LEXER_H
+#define KIN_LEXER_H
 
 //< token-types
 typedef enum {

--- a/src/main.c
+++ b/src/main.c
@@ -12,11 +12,11 @@
 
 
 
-// Our Klang REPL.
+// Our Kin-lang REPL.
 static void repl() {
   char line[1024]; // storing megabyte -> 1024 characters
   while (true) {
-    printf("klang >> ");
+    printf("kin >> ");
 
     if (!fgets(line, sizeof(line), stdin)) {
       printf("\n");

--- a/src/readme.md
+++ b/src/readme.md
@@ -1,7 +1,7 @@
-Klang - Interpreter
+Kin-lang - Interpreter
 ===================
 
-Here is where You'll find implementation of our ```Klang's``` ```Tree-Walk Interpreter```
+Here is where You'll find implementation of our ```Kin-lang's``` ```Tree-Walk Interpreter```
 ``.h`` files contains our self-defined headers which contains utility functions, enums, structures ...
 
 How it Works
@@ -17,4 +17,4 @@ Please refer to [Contributing.md](../contributing.md).
 Licese
 ------
 
-This project is under [Apache License 2.0 LICENSE](https://github.com/pacifiquem/klang/blob/main/LICENSE).
+This project is under [Apache License 2.0 LICENSE](https://github.com/kin-lang/kin/blob/main/LICENSE).


### PR DESCRIPTION
Found out that klang already exist, we're going to go with *kin* as our language's name.