### PR TITLE
feat: objects having member functions

### DIFF
--- a/todo.md
+++ b/todo.md
@@ -1,17 +1,1 @@
 # Todo
-
-1. **Objects having member functions.**
-```kin
-reka obj = {
-    function: porogaramu_ntoya () {
-        # some statements
-    }
-}
-```
-
-Even though these functionalities can be achieved by nesting functions, in Kin you can do:
-```kin
-foo.bar()
-```
-if inside foo function we have bar function.
-


### PR DESCRIPTION
We have a way a function can have a member function.
```kin
porogaramu_ntoya add(a, b) {
    tanga a + b
}

reka obj = {
    addNumbers: add
}   

tangaza_amakuru(obj.addNumbers(1, 2)) // this will print 3 to the screen
```

Even though we can declare a function inside an object declaration, we're able to label a function with a key in an object and the function can be called from there.