### PR TITLE
feat: negation expressions

### DIFF
--- a/src/parser/ast.ts
+++ b/src/parser/ast.ts
@@ -16,6 +16,7 @@ export type NodeType =
   | 'MemberExpression'
   | 'CallExpression'
   | 'BinaryExpr'
+  | 'UnaryExpr'
   | 'ReturnExpr'
 
   // Literals
@@ -105,6 +106,16 @@ export interface BinaryExpr extends Expr {
   operator: string; // must be of type BinaryOperator
   left: Expr;
   right: Expr;
+}
+
+/**
+ * Defines a unary expression
+ */
+
+export interface UnaryExpr extends Expr {
+  kind: 'UnaryExpr';
+  operator: string;
+  variable: string;
 }
 
 // foo["bar"]()  should work

--- a/src/parser/parser.ts
+++ b/src/parser/parser.ts
@@ -24,6 +24,7 @@ import {
   StringLiteral,
   VariableDeclaration,
   ReturnExpr,
+  UnaryExpr,
 } from './ast';
 
 export default class Parser {
@@ -200,11 +201,30 @@ export default class Parser {
         ); // closing paren
 
         return value;
+      // ! We'll make arr of unary operators when we get more than one.
+      case TokenType.NEGATION:
+        return this.parse_negation_expr();
       default:
         return LogError(
           `On line ${this.at().line}: Kin Error: Unexpected token ${this.at().lexeme}`,
         );
     }
+  }
+
+  private parse_negation_expr(): Expr {
+    const operator = this.expect(
+      TokenType.NEGATION,
+      'Expected ! Operator',
+    ).lexeme;
+    const variable = this.expect(
+      TokenType.IDENTIFIER,
+      `Expected identifier after unary operator ${operator}`,
+    ).lexeme;
+    return {
+      kind: 'UnaryExpr',
+      operator,
+      variable,
+    } as UnaryExpr;
   }
 
   private parse_logical_expr(): Expr {

--- a/src/runtime/eval/expressions.ts
+++ b/src/runtime/eval/expressions.ts
@@ -23,10 +23,12 @@ import {
   MemberExpr,
   BinaryExpr,
   CallExpr,
+  UnaryExpr,
 } from '../../parser/ast';
 
 import Environment from '../environment';
 import { Interpreter } from '../interpreter';
+import { LogError } from '../../lib/log';
 
 export default class EvalExpr {
   public static eval_identifier(
@@ -48,6 +50,23 @@ export default class EvalExpr {
       rhs as RuntimeVal,
       node.operator,
     );
+  }
+
+  public static eval_unary_expr(node: UnaryExpr, env: Environment): RuntimeVal {
+    const ident: RuntimeVal = env.lookupVar(node.variable);
+    let value;
+    switch (node.operator) {
+      case '!':
+        value = MK_BOOL(!(ident as BooleanVal).value);
+        break;
+      default:
+        LogError(
+          'Unsupported unary operator ',
+          node.operator,
+          ' report this issue to our developers',
+        );
+    }
+    return value as RuntimeVal;
   }
 
   public static eval_assignment(

--- a/src/runtime/interpreter.ts
+++ b/src/runtime/interpreter.ts
@@ -19,6 +19,7 @@ import {
   StringLiteral,
   ConditionalStmt,
   VariableDeclaration,
+  UnaryExpr,
 } from '../parser/ast';
 
 import Environment from './environment';
@@ -51,6 +52,8 @@ export class Interpreter {
         return EvalExpr.eval_assignment(astNode as AssignmentExpr, env);
       case 'BinaryExpr':
         return EvalExpr.eval_binary_expr(astNode as BinaryExpr, env);
+      case 'UnaryExpr':
+        return EvalExpr.eval_unary_expr(astNode as UnaryExpr, env);
       case 'MemberExpression':
         return EvalExpr.eval_member_expr(env, undefined, astNode as MemberExpr);
       // Handle statements


### PR DESCRIPTION
I forgot to add support for negation operator (!) even though it was tokenized by lexer but somehow while parsing I forgot it.
we've added it and also structured code so that it'll support future support for other unary operators.