### PR TITLE
fix(runtime) : for non-built in functions, number of arguments must equal to number of function's params

### DIFF
--- a/src/runtime/eval/expressions.ts
+++ b/src/runtime/eval/expressions.ts
@@ -115,9 +115,14 @@ export default class EvalExpr {
       const func = fn as FunctionValue;
       const scope = new Environment(func.declarationEnv);
 
+      if (args.length != func.parameters.length) {
+        LogError(
+          "Kin Error: number of function's arguments must equal to it's the parameters",
+        );
+      }
+
       // Create the variables for the parameters list
       for (let i = 0; i < func.parameters.length; i++) {
-        // TODO check the bounds here
         // verify arity of function
         const varname = func.parameters[i];
         scope.declareVar(varname, args[i], false);

--- a/src/runtime/globals.ts
+++ b/src/runtime/globals.ts
@@ -447,6 +447,61 @@ export function createGlobalEnv(filename: string): Environment {
               .join('');
             return MK_STRING(str);
           }),
+        )
+        .set(
+          'injiza_ahabanza',
+          MK_NATIVE_FN((args) => {
+            const MIN_ARGS_LENGTH = 2;
+            if (args.length < MIN_ARGS_LENGTH)
+              throw new Error(
+                'KIN_URUTONDE.injiza_ahabanza expects at least two arguments',
+              );
+            const obj = args[0] as ObjectVal;
+            if (typeof obj != 'object')
+              throw new Error(
+                'KIN_URUTONDE.injiza_ahabanza expects an argument to be an array',
+              );
+            const val = args[1] as RuntimeVal;
+
+            // New array with new value
+            const newArr: ObjectVal = { type: 'object', properties: new Map() };
+
+            // Setting values accordingly && Shift existing elements' keys by 1
+            newArr.properties.set('0', val);
+
+            for (const [key, value] of obj.properties) {
+              newArr.properties.set((parseInt(key) + 1).toString(), value);
+            }
+
+            return newArr;
+          }),
+        )
+        .set(
+          'siba_ahabanza',
+          MK_NATIVE_FN((args) => {
+            const MIN_ARGS_LENGTH = 1;
+            if (args.length < MIN_ARGS_LENGTH)
+              throw new Error(
+                'KIN_URUTONDE.siba_ahabanza expects at least one argument',
+              );
+            const obj = args[0] as ObjectVal;
+            if (typeof obj != 'object')
+              throw new Error(
+                'KIN_URUTONDE.siba_ahabanza expects an argument to be an array',
+              );
+
+            // New array with removed value
+            const newArr: ObjectVal = { type: 'object', properties: new Map() };
+
+            // Skip the first element
+            for (const [key, value] of obj.properties) {
+              if (parseInt(key) !== 0) {
+                newArr.properties.set((parseInt(key) - 1).toString(), value);
+              }
+            }
+
+            return newArr;
+          }),
         ),
     ),
     true,


### PR DESCRIPTION
Arguments of a function while it's being called must equal to the number of parameters it had while it was being declared.