### PR TITLE
feat: allowed `injiza_amakuru()` to have multiple args

### DIFF
--- a/src/runtime/globals.ts
+++ b/src/runtime/globals.ts
@@ -19,7 +19,7 @@ import {
   ObjectVal,
 } from './values';
 import Environment from './environment';
-import { printValues } from './print';
+import { makeValues, printValues } from './print';
 import moment from 'moment';
 import {
   readFileSync,
@@ -75,7 +75,7 @@ export function createGlobalEnv(filename: string): Environment {
       const MIN_ARGS_LENGTH = 1;
       if (args.length < MIN_ARGS_LENGTH)
         LogError('injiza_amakuru expects at least one argument');
-      const cmd = (args[0] as StringVal).value;
+      const cmd = makeValues(args).value;
 
       try {
         const result = prompt()(cmd);

--- a/src/runtime/print.ts
+++ b/src/runtime/print.ts
@@ -10,6 +10,7 @@ import {
   BooleanVal,
   ObjectVal,
   FunctionValue,
+  MK_STRING,
 } from './values';
 
 import { LogMessage } from '../lib/log';
@@ -21,6 +22,16 @@ export function printValues(args: Array<RuntimeVal>) {
     output += matchType(arg);
   }
   LogMessage(output);
+}
+
+// Utility for injiza_amakuru(), helps injiza_amakuru() to have multiple arguments
+export function makeValues(args: Array<RuntimeVal>) {
+  let output = '';
+  for (let i = 0; i < args.length; i++) {
+    const arg = args[i];
+    output += matchType(arg);
+  }
+  return MK_STRING(output);
 }
 
 export function matchType(arg: RuntimeVal) {


### PR DESCRIPTION
Now this will work,

```Kin
reka urutonde_rwi_imibare = []
reka umubare_wimibare = injiza_amakuru("Uratanga imibare ingahe? ")

reka i = 1
reka j = 0

subiramo_niba(i <= umubare_wimibare) {
  reka umubare = injiza_amakuru("Shyiramo umubare wa ", i, ": ")
  KIN_URUTONDE.ongera_kumusozo(urutonde_rwi_imibare, umubare)
  i = i + 1
}
```

Observed this line? `injiza_amakuru("Shyiramo umubare wa ", i, ": ")`

Yes this will prompt user to enter a number and showing corresponding index we're at.