### PR TITLE
docs: add introduction video to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,6 +16,12 @@
 
 </div>
 
+## Introduction
+
+Get a quick overview of Kin in action:
+
+https://github.com/kin-lang/kin/raw/main/public/introductionproject.mp4
+
 ## Description
 
 **Kin** is a straightforward programming language created with the purpose of aiding Rwandans to write computer programs in their native language Kinyarwanda.


### PR DESCRIPTION
## Summary

- Adds a new **Introduction** section near the top of the README with an embedded overview video of Kin
- Stores the video at `public/introductionproject.mp4` (compressed to stay under GitHub's 100MB upload limit)
- Helps newcomers quickly understand what Kin is and how it works before reading the full docs

## Notes

- Source video was ~113MB / 44 minutes; it was re-encoded (H.264 + AAC, CRF 32) to ~90MB so it can live in the repo without Git LFS
- GitHub may show a warning for files over 50MB; the embed uses the standard `raw/main/...mp4` URL which GitHub renders as an inline player in the README

## Test plan

- [ ] Open the PR diff and confirm `README.md` has the Introduction section with the video link
- [ ] After merge (or via branch preview), confirm the video plays on the rendered README at https://github.com/kin-lang/kin
- [ ] Confirm `public/introductionproject.mp4` is present and accessible via the blob/raw URL