### PR TITLE
chore: point website links to kinlang.vercel.app

### DIFF
--- a/bin/README.md
+++ b/bin/README.md
@@ -1,5 +1,5 @@
 <p align="center">
-  <a href="https://kinlang.dev/" target="blank"><img src="https://github.com/kin-lang/kin/blob/main/public/kin-logo.svg" width="120" alt="Kin Logo" /></a>
+  <a href="https://kinlang.vercel.app/" target="blank"><img src="https://github.com/kin-lang/kin/blob/main/public/kin-logo.svg" width="120" alt="Kin Logo" /></a>
 </p>
 
 <p align="center">Write computer programs in Kinyarwanda! </p>


### PR DESCRIPTION
## Summary
- Replace outdated `https://kinlang.dev/` URL in the CLI package README with `https://kinlang.vercel.app/`

## Notes
- Docs/site links only; no release
- Contact emails (`@kinlang.dev`) left unchanged