### PR TITLE
fix: parse nested parenthesized logical expressions (#58)

### DIFF
--- a/grammar.bnf
+++ b/grammar.bnf
@@ -104,9 +104,9 @@ objectProperty ::= identifier (":" expression)?
 ; keys are "0", "1", ...
 arrayLiteral ::= "[" (expression ("," expression)* ","?)? "]"
 
-; Note: at most one && or ||. They share a single precedence and do not
-; chain:  a && b || c  is not one logical expression.
-logicalExpression ::= relationalExpression (("&&" | "||") relationalExpression)?
+; && and || share a single precedence and are left-associative.
+; They chain so grouped expressions consume every operator before ')'.
+logicalExpression ::= relationalExpression (("&&" | "||") relationalExpression)*
 
 ; Note: at most one relational operator. They do not chain:
 ;  a < b < c  is not one comparison.
@@ -144,8 +144,9 @@ primaryExpression ::= identifier
                     | "(" expression ")"
                     | unaryNot
 
-; Note: ! applies only to an identifier, not to a general expression.
-unaryNot ::= "!" identifier
+; ! applies to a primary expression: identifier, literal, or grouped expr.
+; This allows both !flag and !(a != b).
+unaryNot ::= "!" primaryExpression
 
 ; ========================================
 ; Lexical

--- a/src/parser/ast.ts
+++ b/src/parser/ast.ts
@@ -135,7 +135,7 @@ export interface BinaryExpr extends Expr {
 export interface UnaryExpr extends Expr {
   kind: 'UnaryExpr';
   operator: string;
-  variable: string;
+  operand: Expr;
 }
 
 // foo["bar"]()  should work

--- a/src/parser/parser.ts
+++ b/src/parser/parser.ts
@@ -311,21 +311,21 @@ export default class Parser {
       TokenType.NEGATION,
       'Expected ! Operator',
     ).lexeme;
-    const variable = this.expect(
-      TokenType.IDENTIFIER,
-      `Expected identifier after unary operator ${operator}`,
-    ).lexeme;
+    // Allow !ident, !(expr), and stacked !!x via primary expressions.
+    const operand = this.parse_primary_expr();
     return {
       kind: 'UnaryExpr',
       operator,
-      variable,
+      operand,
     } as UnaryExpr;
   }
 
   private parse_logical_expr(): Expr {
     let left = this.parse_relational_expr();
 
-    if (['&&', '||'].includes(this.at().lexeme)) {
+    // Chain && and || (same precedence, left-associative) so a grouped
+    // expression like (a && b || c) consumes every operator before ')'.
+    while (['&&', '||'].includes(this.at().lexeme)) {
       const operator = this.eat().lexeme;
       const right = this.parse_relational_expr();
       left = {

--- a/src/runtime/eval/expressions.ts
+++ b/src/runtime/eval/expressions.ts
@@ -57,11 +57,11 @@ export default class EvalExpr {
   }
 
   public static eval_unary_expr(node: UnaryExpr, env: Environment): RuntimeVal {
-    const ident: RuntimeVal = env.lookupVar(node.variable);
+    const operand: RuntimeVal = Interpreter.evaluate(node.operand, env);
     let value;
     switch (node.operator) {
       case '!':
-        value = MK_BOOL(!(ident as BooleanVal).value);
+        value = MK_BOOL(!(operand as BooleanVal).value);
         break;
       default:
         LogError(

--- a/tests/expressions.test.ts
+++ b/tests/expressions.test.ts
@@ -1,0 +1,102 @@
+import { describe, expect, test } from 'vitest';
+import { asBool, evaluate } from './helpers';
+
+describe('nested parenthesized expressions (issue #58)', () => {
+  test('evaluates the reported ((var > var2) && !(var3 != var4) || (var5 == var6))', () => {
+    const { result } = evaluate(`
+      reka var = 10
+      reka var2 = 5
+      reka var3 = 1
+      reka var4 = 1
+      reka var5 = 2
+      reka var6 = 2
+      reka result = ((var > var2) && !(var3 != var4) || (var5 == var6))
+      result
+    `);
+
+    expect(asBool(result)).toBe(true);
+  });
+
+  test('evaluates the reported expression when the first clause is false', () => {
+    const { result } = evaluate(`
+      reka var = 1
+      reka var2 = 5
+      reka var3 = 1
+      reka var4 = 1
+      reka var5 = 2
+      reka var6 = 2
+      reka result = ((var > var2) && !(var3 != var4) || (var5 == var6))
+      result
+    `);
+
+    // (false && true) || true
+    expect(asBool(result)).toBe(true);
+  });
+
+  test('evaluates the reported expression as false when every clause is false', () => {
+    const { result } = evaluate(`
+      reka var = 1
+      reka var2 = 5
+      reka var3 = 1
+      reka var4 = 2
+      reka var5 = 2
+      reka var6 = 3
+      reka result = ((var > var2) && !(var3 != var4) || (var5 == var6))
+      result
+    `);
+
+    // (false && false) || false
+    expect(asBool(result)).toBe(false);
+  });
+
+  test('evaluates negation of a parenthesized comparison', () => {
+    const { result: notEqual } = evaluate(`
+      reka a = 1
+      reka b = 2
+      !(a == b)
+    `);
+    expect(asBool(notEqual)).toBe(true);
+
+    const { result: equal } = evaluate(`
+      reka a = 1
+      reka b = 1
+      !(a == b)
+    `);
+    expect(asBool(equal)).toBe(false);
+  });
+
+  test('evaluates chained logical operators inside parentheses', () => {
+    const { result } = evaluate(`
+      reka a = sibyo
+      reka b = nibyo
+      reka c = nibyo
+      reka result = (a && b || c)
+      result
+    `);
+
+    // (false && true) || true
+    expect(asBool(result)).toBe(true);
+  });
+
+  test('evaluates deeply nested grouped comparisons', () => {
+    const { result } = evaluate(`
+      reka a = 3
+      reka b = 1
+      reka c = 0
+      reka d = 4
+      reka result = (((a > b) && (c < d)))
+      result
+    `);
+
+    expect(asBool(result)).toBe(true);
+  });
+
+  test('still evaluates !identifier on a boolean variable', () => {
+    const { result } = evaluate(`
+      reka flag = nibyo
+      !flag
+    `);
+
+    expect(asBool(result)).toBe(false);
+  });
+});

--- a/tests/parser.test.ts
+++ b/tests/parser.test.ts
@@ -431,4 +431,143 @@ describe('Parser', () => {
     const parser = new Parser();
     expect(() => parser.produceAST(sourceCode)).toThrowError();
   });
+
+  // Issue #58: nested parentheses with chained logical ops and !(expr)
+  test('should parse nested parenthesized logical and comparison expression (issue #58)', () => {
+    const sourceCode =
+      'reka result = ((var > var2) && !(var3 != var4) || (var5 == var6))';
+    const parser = new Parser();
+    const ast = parser.produceAST(sourceCode);
+
+    const expectedAst = {
+      kind: 'Program',
+      body: [
+        {
+          kind: 'VariableDeclaration',
+          constant: false,
+          identifier: 'result',
+          value: {
+            kind: 'BinaryExpr',
+            operator: '||',
+            left: {
+              kind: 'BinaryExpr',
+              operator: '&&',
+              left: {
+                kind: 'BinaryExpr',
+                operator: '>',
+                left: { kind: 'Identifier', symbol: 'var' },
+                right: { kind: 'Identifier', symbol: 'var2' },
+              },
+              right: {
+                kind: 'UnaryExpr',
+                operator: '!',
+                operand: {
+                  kind: 'BinaryExpr',
+                  operator: '!=',
+                  left: { kind: 'Identifier', symbol: 'var3' },
+                  right: { kind: 'Identifier', symbol: 'var4' },
+                },
+              },
+            },
+            right: {
+              kind: 'BinaryExpr',
+              operator: '==',
+              left: { kind: 'Identifier', symbol: 'var5' },
+              right: { kind: 'Identifier', symbol: 'var6' },
+            },
+          },
+        },
+      ],
+    };
+
+    expect(ast).toEqual(expectedAst);
+  });
+
+  test('should parse negation of a parenthesized comparison', () => {
+    const sourceCode = 'reka result = !(a == b)';
+    const parser = new Parser();
+    const ast = parser.produceAST(sourceCode);
+
+    expect(ast).toEqual({
+      kind: 'Program',
+      body: [
+        {
+          kind: 'VariableDeclaration',
+          constant: false,
+          identifier: 'result',
+          value: {
+            kind: 'UnaryExpr',
+            operator: '!',
+            operand: {
+              kind: 'BinaryExpr',
+              operator: '==',
+              left: { kind: 'Identifier', symbol: 'a' },
+              right: { kind: 'Identifier', symbol: 'b' },
+            },
+          },
+        },
+      ],
+    });
+  });
+
+  test('should parse chained logical operators inside parentheses', () => {
+    const sourceCode = 'reka result = (a && b || c)';
+    const parser = new Parser();
+    const ast = parser.produceAST(sourceCode);
+
+    expect(ast).toEqual({
+      kind: 'Program',
+      body: [
+        {
+          kind: 'VariableDeclaration',
+          constant: false,
+          identifier: 'result',
+          value: {
+            kind: 'BinaryExpr',
+            operator: '||',
+            left: {
+              kind: 'BinaryExpr',
+              operator: '&&',
+              left: { kind: 'Identifier', symbol: 'a' },
+              right: { kind: 'Identifier', symbol: 'b' },
+            },
+            right: { kind: 'Identifier', symbol: 'c' },
+          },
+        },
+      ],
+    });
+  });
+
+  test('should parse deeply nested grouped comparisons', () => {
+    const sourceCode = 'reka result = (((a > b) && (c < d)))';
+    const parser = new Parser();
+    const ast = parser.produceAST(sourceCode);
+
+    expect(ast).toEqual({
+      kind: 'Program',
+      body: [
+        {
+          kind: 'VariableDeclaration',
+          constant: false,
+          identifier: 'result',
+          value: {
+            kind: 'BinaryExpr',
+            operator: '&&',
+            left: {
+              kind: 'BinaryExpr',
+              operator: '>',
+              left: { kind: 'Identifier', symbol: 'a' },
+              right: { kind: 'Identifier', symbol: 'b' },
+            },
+            right: {
+              kind: 'BinaryExpr',
+              operator: '<',
+              left: { kind: 'Identifier', symbol: 'c' },
+              right: { kind: 'Identifier', symbol: 'd' },
+            },
+          },
+        },
+      ],
+    });
+  });
 });


### PR DESCRIPTION
## Kin Pull Request

**Summary of Changes**
Bug fix for #58: Kin now parses nested parenthesized logical and comparison expressions such as `((var > var2) && !(var3 != var4) || (var5 == var6))`.

**Description of Changes**
Two parser limits made that expression fail:
1. `&&` and `||` did not chain (`if` instead of `while`), so after `a && b` the leftover `||` meant the closing `)` was never eaten.
2. `!` only accepted an identifier, so `!(var3 != var4)` threw `Expected identifier after unary operator !`.

Changes:
- Chain `&&` / `||` as left-associative operators at the same precedence so grouped expressions consume every operator before `)`.
- Let `!` apply to a primary expression (`!flag`, `!(a != b)`, `!!x`).
- Represent unary nodes as `{ operator, operand }` and evaluate the operand.
- Update `grammar.bnf` to match the implementation.

**Testing**
- Added parser tests for the reported expression and similar nestings (`!(a == b)`, `(a && b || c)`, `(((a > b) && (c < d)))`).
- Added runtime tests that evaluate those expressions.
- Full suite: `159` tests passed (`npm test`).

**Screenshots or Recordings**
N/A

**Checklist**
* [x] I have performed a self-review of my code.
* [x] I have added thorough tests for any new features.
* [x] I have updated the documentation to reflect the changes made in this pull request.
* [ ] I have addressed any comments or questions raised by reviewers.

**Additional Notes**
Fixes https://github.com/kin-lang/kin/issues/58

**Thank you for contributing to Kin!**