### PR TITLE
feat: categorize Kin errors with ERRNAME and ERRCODE

### DIFF
--- a/bin/kin.ts
+++ b/bin/kin.ts
@@ -3,7 +3,12 @@
 import { program } from 'commander';
 import pkg from '../package.json';
 import { readFile } from 'fs/promises';
-import { Interpreter, Parser, createGlobalEnv } from '../src/index';
+import {
+  Interpreter,
+  Parser,
+  createGlobalEnv,
+  formatKinError,
+} from '../src/index';
 import * as readline from 'readline/promises';
 
 const rl = readline.createInterface({
@@ -41,12 +46,11 @@ program
         process.exit(1);
       }
 
-      const program = parser.produceAST(input);
-
       try {
+        const program = parser.produceAST(input);
         Interpreter.evaluate(program, env);
       } catch (error: unknown) {
-        console.error(error instanceof Error ? error.message : error);
+        console.error(formatKinError(error));
       }
     }
   });
@@ -62,16 +66,23 @@ program
       const env = createGlobalEnv(file_location); // create global environment for Kin
       Interpreter.evaluate(ast, env); // Evaluate the program
       process.exit(0);
-      // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    } catch (error: any) {
-      if (error.code === 'ENOENT') {
+    } catch (error: unknown) {
+      if (isNodeErrno(error) && error.code === 'ENOENT') {
         console.error(`Kin Error: Can't resolve file at '${file_location}'`);
       } else {
-        const message = error.message ? error.message : error;
-        console.error(`Kin Error: ${message}`);
+        console.error(`Kin Error: ${formatKinError(error)}`);
       }
       process.exit(1);
     }
   });
 
 program.parse();
+
+function isNodeErrno(error: unknown): error is NodeJS.ErrnoException {
+  return (
+    typeof error === 'object' &&
+    error !== null &&
+    'code' in error &&
+    typeof (error as NodeJS.ErrnoException).code === 'string'
+  );
+}

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -42,6 +42,13 @@ export default tseslint.config(
   {
     files: ['tests/**/*.ts'],
     ...vitest.configs.recommended,
+    rules: {
+      ...vitest.configs.recommended.rules,
+      'vitest/expect-expect': [
+        'error',
+        { assertFunctionNames: ['expect', 'expectKinError'] },
+      ],
+    },
   },
   eslintPluginPrettierRecommended,
 );

--- a/src/index.ts
+++ b/src/index.ts
@@ -4,6 +4,17 @@ import { Interpreter } from './runtime/interpreter';
 import { createGlobalEnv } from './runtime/globals';
 import Environment from './runtime/environment';
 import {
+  KinError,
+  KinSyntaxError,
+  KinTypeError,
+  KinReferenceError,
+  KinRuntimeError,
+  isKinError,
+  formatKinError,
+  KinErrorName,
+  KinErrorCode,
+} from './lib/errors';
+import {
   MK_NUMBER,
   MK_STRING,
   MK_NULL,
@@ -31,6 +42,13 @@ export {
   MK_BOOL,
   MK_OBJECT,
   MK_NATIVE_FN,
+  KinError,
+  KinSyntaxError,
+  KinTypeError,
+  KinReferenceError,
+  KinRuntimeError,
+  isKinError,
+  formatKinError,
 };
 
 export type {
@@ -41,4 +59,6 @@ export type {
   ObjectVal,
   FunctionValue,
   NullVal,
+  KinErrorName,
+  KinErrorCode,
 };

--- a/src/lexer/lexer.ts
+++ b/src/lexer/lexer.ts
@@ -3,6 +3,7 @@
  *     Produce tokens from the source     *
  ******************************************/
 
+import { KinSyntaxError } from '../lib/errors';
 import TokenType from './tokens';
 
 /* Token structure */
@@ -116,8 +117,9 @@ class Lexer {
     const quote: string = this.consume();
     while (this.peek() !== quote) {
       if (this.peek() === '\n' || this.currentPos === this.sourceCodes.length) {
-        throw new Error(
+        throw new KinSyntaxError(
           `Unterminated string literal at line ${this.currentLine}`,
+          { line: this.currentLine },
         );
       }
       this.advance();
@@ -239,7 +241,10 @@ class Lexer {
           this.advance();
           return this.makeTokenWithLexeme(TokenType.OR, '||');
         }
-        throw new Error(`Unexpected character '|' at line ${this.currentLine}`);
+        throw new KinSyntaxError(
+          `Unexpected character '|' at line ${this.currentLine}`,
+          { line: this.currentLine },
+        );
       case ';':
         this.advance();
         return this.makeTokenWithLexeme(TokenType.SEMI_COLON, ';');
@@ -295,8 +300,9 @@ class Lexer {
         } else if (this.isSingleAlphaCharacter(char) || char === '_') {
           return this.scanIdentifierOrKeyword();
         } else {
-          throw new Error(
+          throw new KinSyntaxError(
             `Unexpected character '${char}' at line ${this.currentLine}`,
+            { line: this.currentLine },
           );
         }
     }

--- a/src/lib/errors.ts
+++ b/src/lib/errors.ts
@@ -1,0 +1,93 @@
+/******************************************
+ *              Kin Errors                *
+ *   Categorized errors with name + code  *
+ ******************************************/
+
+export type KinErrorName =
+  'SyntaxError' | 'TypeError' | 'ReferenceError' | 'RuntimeError';
+
+export type KinErrorCode = 'E_SYNTAX' | 'E_TYPE' | 'E_REFERENCE' | 'E_RUNTIME';
+
+export interface KinErrorOptions {
+  line?: number;
+  cause?: unknown;
+}
+
+/**
+ * Base class for every Kin language error.
+ *
+ * `ERRNAME` is the public category (SyntaxError, TypeError, ...).
+ * `ERRCODE` is a stable machine-readable code (E_SYNTAX, E_TYPE, ...).
+ * Host programs and tests can distinguish errors via `instanceof`,
+ * `ERRNAME`, or `ERRCODE`.
+ */
+export class KinError extends Error {
+  readonly ERRNAME: KinErrorName;
+  readonly ERRCODE: KinErrorCode;
+  readonly line?: number;
+
+  constructor(
+    message: string,
+    name: KinErrorName,
+    code: KinErrorCode,
+    options?: KinErrorOptions,
+  ) {
+    super(
+      message,
+      options?.cause !== undefined ? { cause: options.cause } : undefined,
+    );
+    this.name = name;
+    this.ERRNAME = name;
+    this.ERRCODE = code;
+    this.line = options?.line;
+    Object.setPrototypeOf(this, new.target.prototype);
+  }
+
+  /** Node-style alias so `error.code` matches `ERRCODE`. */
+  get code(): KinErrorCode {
+    return this.ERRCODE;
+  }
+}
+
+/** Lexer / parser failures (bad tokens, unexpected syntax). */
+export class KinSyntaxError extends KinError {
+  constructor(message: string, options?: KinErrorOptions) {
+    super(message, 'SyntaxError', 'E_SYNTAX', options);
+  }
+}
+
+/** Wrong value type or arity (bad index, non-callable, native-fn args). */
+export class KinTypeError extends KinError {
+  constructor(message: string, options?: KinErrorOptions) {
+    super(message, 'TypeError', 'E_TYPE', options);
+  }
+}
+
+/** Lookup of a name that is not in scope. */
+export class KinReferenceError extends KinError {
+  constructor(message: string, options?: KinErrorOptions) {
+    super(message, 'ReferenceError', 'E_REFERENCE', options);
+  }
+}
+
+/** Everything else that happens while running a program. */
+export class KinRuntimeError extends KinError {
+  constructor(message: string, options?: KinErrorOptions) {
+    super(message, 'RuntimeError', 'E_RUNTIME', options);
+  }
+}
+
+export function isKinError(error: unknown): error is KinError {
+  return error instanceof KinError;
+}
+
+/** Format an error for the CLI / REPL. */
+export function formatKinError(error: unknown): string {
+  if (error instanceof KinError) {
+    return `${error.ERRNAME} [${error.ERRCODE}]: ${error.message}`;
+  }
+  if (error instanceof Error) {
+    return error.message;
+  }
+  return String(error);
+}

--- a/src/lib/log.ts
+++ b/src/lib/log.ts
@@ -3,8 +3,18 @@
  *      utility for loggin messages     *
  ****************************************/
 
+import { KinRuntimeError, KinTypeError } from './errors';
+
 export const LogMessage = console.log;
-export const LogError = (...args: unknown[]) => {
+
+/** Throw a generic runtime error. Prefer a specific Kin*Error when the category is known. */
+export const LogError = (...args: unknown[]): never => {
   const message = args.map((arg) => String(arg)).join(' ');
-  throw new Error(message);
+  throw new KinRuntimeError(message);
+};
+
+/** Throw a TypeError — used by native builtins for arity/type checks. */
+export const LogTypeError = (...args: unknown[]): never => {
+  const message = args.map((arg) => String(arg)).join(' ');
+  throw new KinTypeError(message);
 };

--- a/src/parser/parser.ts
+++ b/src/parser/parser.ts
@@ -5,7 +5,7 @@
 
 import Lexer, { Token } from '../lexer/lexer';
 import TokenType from '../lexer/tokens';
-import { LogError } from '../lib/log';
+import { KinSyntaxError } from '../lib/errors';
 import {
   AssignmentExpr,
   BinaryExpr,
@@ -49,7 +49,10 @@ export default class Parser {
     const prev = this.eat();
 
     if (!prev || prev.type != type) {
-      LogError(`On line ${prev.line}: Kin Error: ${err}, found ${prev.lexeme}`);
+      throw new KinSyntaxError(
+        `On line ${prev.line}: Kin Error: ${err}, found ${prev.lexeme}`,
+        { line: prev.line },
+      );
     }
 
     return prev;
@@ -227,7 +230,7 @@ export default class Parser {
       this.eat();
 
       if (isConstant)
-        throw new Error('Constant variables must be assigned a value');
+        throw new KinSyntaxError('Constant variables must be assigned a value');
 
       return {
         kind: 'VariableDeclaration',
@@ -300,8 +303,9 @@ export default class Parser {
       case TokenType.NEGATION:
         return this.parse_negation_expr();
       default:
-        return LogError(
+        throw new KinSyntaxError(
           `On line ${this.at().line}: Kin Error: Unexpected token ${this.at().lexeme}`,
+          { line: this.at().line },
         );
     }
   }
@@ -418,7 +422,7 @@ export default class Parser {
         property = this.parse_primary_expr();
 
         if (property.kind !== 'Identifier') {
-          throw new Error(
+          throw new KinSyntaxError(
             'Dot operator (".") is illegal without right-hand-side (<-) being an Identifier.',
           );
         }
@@ -593,8 +597,9 @@ export default class Parser {
 
     for (const arg of args) {
       if (arg.kind != 'Identifier') {
-        LogError(
+        throw new KinSyntaxError(
           `On line ${this.at().line}: Kin Error: Expected identifier for function parameter`,
+          { line: this.at().line },
         );
       }
 

--- a/src/runtime/environment.ts
+++ b/src/runtime/environment.ts
@@ -6,7 +6,11 @@
 
 import { Interpreter } from '..';
 import { Identifier, MemberExpr } from '../parser/ast';
-import { LogError } from '../lib/log';
+import {
+  KinReferenceError,
+  KinRuntimeError,
+  KinTypeError,
+} from '../lib/errors';
 import { MK_NULL, NumberVal, ObjectVal, RuntimeVal, StringVal } from './values';
 
 export default class Environment {
@@ -26,7 +30,7 @@ export default class Environment {
     constant: boolean,
   ): RuntimeVal {
     if (this.variables.has(varname)) {
-      throw new Error(
+      throw new KinRuntimeError(
         `Cannot declare variable ${varname}. As it already is defined.`,
       );
     }
@@ -43,7 +47,7 @@ export default class Environment {
 
     // Cannot assign to constant
     if (env.constants.has(varname)) {
-      throw new Error(
+      throw new KinRuntimeError(
         `Cannot reassign to variable "${varname}" as it's constant.`,
       );
     }
@@ -100,7 +104,7 @@ export default class Environment {
       const type =
         obj === undefined || obj.type === 'null' ? 'ubusa' : obj.type;
 
-      LogError(`Cannot access property '${key}' of ${type}`);
+      throw new KinTypeError(`Cannot access property '${key}' of ${type}`);
     }
 
     return { obj: obj as ObjectVal, key };
@@ -114,7 +118,7 @@ export default class Environment {
     const evaluated = Interpreter.evaluate(expr.property, this);
 
     if (evaluated.type !== 'string' && evaluated.type !== 'number') {
-      LogError(`Cannot use ${evaluated.type} as an index/key`);
+      throw new KinTypeError(`Cannot use ${evaluated.type} as an index/key`);
     }
 
     return (evaluated as StringVal | NumberVal).value.toString();
@@ -130,7 +134,9 @@ export default class Environment {
     if (this.variables.has(varname)) return this;
 
     if (this.parent == undefined)
-      throw new Error(`Cannot resolve '${varname}' as it does not exist.`);
+      throw new KinReferenceError(
+        `Cannot resolve '${varname}' as it does not exist.`,
+      );
 
     return this.parent.resolve(varname);
   }

--- a/src/runtime/eval/expressions.ts
+++ b/src/runtime/eval/expressions.ts
@@ -29,6 +29,7 @@ import {
 
 import Environment from '../environment';
 import { Interpreter } from '../interpreter';
+import { KinRuntimeError, KinTypeError } from '../../lib/errors';
 import { LogError } from '../../lib/log';
 
 export default class EvalExpr {
@@ -80,7 +81,7 @@ export default class EvalExpr {
     if (node.assigne.kind === 'MemberExpression')
       return this.eval_member_expr(env, node);
     if (node.assigne.kind !== 'Identifier')
-      throw new Error(
+      throw new KinRuntimeError(
         `Invalid left-hand-side expression: ${JSON.stringify(node.assigne)}.`,
       );
 
@@ -122,7 +123,7 @@ export default class EvalExpr {
       const scope = new Environment(func.declarationEnv);
 
       if (args.length != func.parameters.length) {
-        LogError(
+        throw new KinTypeError(
           "Kin Error: number of function's arguments must equal to it's the parameters",
         );
       }
@@ -154,7 +155,7 @@ export default class EvalExpr {
       return result;
     }
 
-    throw new Error(
+    throw new KinTypeError(
       'Cannot call value that is not a function: ' + JSON.stringify(fn),
     );
   }
@@ -185,7 +186,7 @@ export default class EvalExpr {
         Interpreter.evaluate(node.value, env),
       );
     } else {
-      throw new Error(
+      throw new KinRuntimeError(
         `Evaluating a member expression is not possible without a member or assignment expression.`,
       );
     }
@@ -236,7 +237,7 @@ export default class EvalExpr {
         case '>=':
           return MK_BOOL(llhs.value >= rrhs.value);
         default:
-          throw new Error(
+          throw new KinRuntimeError(
             `Unknown operator provided in operation: ${lhs}, ${rhs}.`,
           );
       }
@@ -282,7 +283,7 @@ export default class EvalExpr {
           compare((lhs as ObjectVal).properties, (rhs as ObjectVal).properties),
         );
       default:
-        throw new Error(
+        throw new KinRuntimeError(
           `RunTime: Unhandled type in equals function: ${lhs}, ${rhs}`,
         );
     }

--- a/src/runtime/globals.ts
+++ b/src/runtime/globals.ts
@@ -28,7 +28,8 @@ import {
   unlinkSync as deleteFileSync,
 } from 'fs';
 import path from 'path';
-import { LogError } from '../lib/log';
+import { KinRuntimeError } from '../lib/errors';
+import { LogTypeError as LogError } from '../lib/log';
 
 export function createGlobalEnv(filename: string): Environment {
   const env = new Environment();
@@ -64,7 +65,7 @@ export function createGlobalEnv(filename: string): Environment {
       } catch (error: unknown) {
         const message =
           error instanceof Error ? error.toString() : String(error);
-        throw new Error(message, { cause: error });
+        throw new KinRuntimeError(message, { cause: error });
       }
     }),
     true,
@@ -91,7 +92,7 @@ export function createGlobalEnv(filename: string): Environment {
       } catch (error: unknown) {
         const message =
           error instanceof Error ? error.toString() : String(error);
-        throw new Error(message, { cause: error });
+        throw new KinRuntimeError(message, { cause: error });
       }
     }),
     true,

--- a/tests/errors.test.ts
+++ b/tests/errors.test.ts
@@ -1,0 +1,279 @@
+import { describe, expect, test } from 'vitest';
+import Lexer from '../src/lexer/lexer';
+import Parser from '../src/parser/parser';
+import {
+  KinError,
+  KinReferenceError,
+  KinRuntimeError,
+  KinSyntaxError,
+  KinTypeError,
+  formatKinError,
+  isKinError,
+} from '../src/lib/errors';
+import { evaluate, expectKinError } from './helpers';
+
+describe('Kin error taxonomy', () => {
+  test('each class exposes a stable ERRNAME and ERRCODE', () => {
+    const syntax = new KinSyntaxError('bad token');
+    const type = new KinTypeError('bad type');
+    const reference = new KinReferenceError('missing name');
+    const runtime = new KinRuntimeError('boom');
+
+    expect(syntax).toBeInstanceOf(KinError);
+    expect(syntax).toBeInstanceOf(Error);
+    expect(syntax.ERRNAME).toBe('SyntaxError');
+    expect(syntax.ERRCODE).toBe('E_SYNTAX');
+    expect(syntax.code).toBe('E_SYNTAX');
+    expect(syntax.name).toBe('SyntaxError');
+
+    expect(type.ERRNAME).toBe('TypeError');
+    expect(type.ERRCODE).toBe('E_TYPE');
+
+    expect(reference.ERRNAME).toBe('ReferenceError');
+    expect(reference.ERRCODE).toBe('E_REFERENCE');
+
+    expect(runtime.ERRNAME).toBe('RuntimeError');
+    expect(runtime.ERRCODE).toBe('E_RUNTIME');
+  });
+
+  test('categories are distinguishable by class, name, and code', () => {
+    const syntax = new KinSyntaxError('x');
+    const type = new KinTypeError('x');
+
+    expect(syntax).not.toBeInstanceOf(KinTypeError);
+    expect(type).not.toBeInstanceOf(KinSyntaxError);
+    expect(syntax.ERRNAME).not.toBe(type.ERRNAME);
+    expect(syntax.ERRCODE).not.toBe(type.ERRCODE);
+    expect(isKinError(syntax)).toBe(true);
+    expect(isKinError(new Error('host'))).toBe(false);
+  });
+
+  test('formatKinError prints ERRNAME and ERRCODE', () => {
+    expect(
+      formatKinError(new KinTypeError('Cannot use null as an index/key')),
+    ).toBe('TypeError [E_TYPE]: Cannot use null as an index/key');
+    expect(formatKinError(new Error('plain'))).toBe('plain');
+    expect(formatKinError('stringy')).toBe('stringy');
+  });
+
+  test('KinTypeError is not the host TypeError', () => {
+    const err = new KinTypeError('kin');
+    expect(err).toBeInstanceOf(KinTypeError);
+    expect(err).not.toBeInstanceOf(TypeError);
+  });
+});
+
+describe('Lexer throws KinSyntaxError', () => {
+  test('unexpected character', () => {
+    expectKinError(() => new Lexer('let x = ~;').tokenize(), KinSyntaxError, {
+      ERRNAME: 'SyntaxError',
+      ERRCODE: 'E_SYNTAX',
+      message: "Unexpected character '~' at line 1",
+    });
+  });
+
+  test('unterminated string', () => {
+    expectKinError(() => new Lexer('"hello').tokenize(), KinSyntaxError, {
+      ERRNAME: 'SyntaxError',
+      ERRCODE: 'E_SYNTAX',
+      message: 'Unterminated string literal at line 1',
+    });
+  });
+
+  test('lone pipe', () => {
+    expectKinError(() => new Lexer('a | b').tokenize(), KinSyntaxError, {
+      ERRNAME: 'SyntaxError',
+      ERRCODE: 'E_SYNTAX',
+      message: "Unexpected character '|' at line 1",
+    });
+  });
+});
+
+describe('Parser throws KinSyntaxError', () => {
+  test('unexpected token in expression', () => {
+    const parser = new Parser();
+    expectKinError(() => parser.produceAST('reka x = ;'), KinSyntaxError, {
+      ERRNAME: 'SyntaxError',
+      ERRCODE: 'E_SYNTAX',
+    });
+  });
+
+  test('constant without a value', () => {
+    const parser = new Parser();
+    expectKinError(() => parser.produceAST('ntahinduka x;'), KinSyntaxError, {
+      ERRNAME: 'SyntaxError',
+      ERRCODE: 'E_SYNTAX',
+      message: 'Constant variables must be assigned a value',
+    });
+  });
+});
+
+describe('Runtime throws categorized Kin errors', () => {
+  test('undefined variable is a ReferenceError', () => {
+    expectKinError(() => evaluate('ntabwo_iriho'), KinReferenceError, {
+      ERRNAME: 'ReferenceError',
+      ERRCODE: 'E_REFERENCE',
+      message: "Cannot resolve 'ntabwo_iriho' as it does not exist.",
+    });
+  });
+
+  test('bad index type is a TypeError', () => {
+    expectKinError(
+      () =>
+        evaluate(`
+          reka arr = [1, 2]
+          arr[ubusa]
+        `),
+      KinTypeError,
+      {
+        ERRNAME: 'TypeError',
+        ERRCODE: 'E_TYPE',
+        message: 'Cannot use null as an index/key',
+      },
+    );
+  });
+
+  test('property access on a primitive is a TypeError', () => {
+    expectKinError(
+      () =>
+        evaluate(`
+          reka x = 5
+          x.foo
+        `),
+      KinTypeError,
+      {
+        ERRNAME: 'TypeError',
+        ERRCODE: 'E_TYPE',
+        message: "Cannot access property 'foo' of number",
+      },
+    );
+  });
+
+  test('calling a non-function is a TypeError', () => {
+    expectKinError(
+      () =>
+        evaluate(`
+          reka x = 1
+          x()
+        `),
+      KinTypeError,
+      {
+        ERRNAME: 'TypeError',
+        ERRCODE: 'E_TYPE',
+        message: 'Cannot call value that is not a function',
+      },
+    );
+  });
+
+  test('wrong function arity is a TypeError', () => {
+    expectKinError(
+      () =>
+        evaluate(`
+          porogaramu_ntoya f(a, b) {
+            tanga a
+          }
+          f(1)
+        `),
+      KinTypeError,
+      {
+        ERRNAME: 'TypeError',
+        ERRCODE: 'E_TYPE',
+        message:
+          "number of function's arguments must equal to it's the parameters",
+      },
+    );
+  });
+
+  test('native-fn arity/type checks are TypeErrors', () => {
+    expectKinError(() => evaluate('ubwoko()'), KinTypeError, {
+      ERRNAME: 'TypeError',
+      ERRCODE: 'E_TYPE',
+      message: 'ubwoko expects at least one argument',
+    });
+    expectKinError(() => evaluate('KIN_AMAGAMBO.ingano(12)'), KinTypeError, {
+      ERRNAME: 'TypeError',
+      ERRCODE: 'E_TYPE',
+      message: 'KIN_AMAGAMBO.ingano expects string as an argument',
+    });
+  });
+
+  test('redeclaring a variable is a RuntimeError', () => {
+    expectKinError(
+      () =>
+        evaluate(`
+          reka x = 1
+          reka x = 2
+        `),
+      KinRuntimeError,
+      {
+        ERRNAME: 'RuntimeError',
+        ERRCODE: 'E_RUNTIME',
+        message: 'Cannot declare variable x. As it already is defined.',
+      },
+    );
+  });
+
+  test('reassigning a constant is a RuntimeError', () => {
+    expectKinError(
+      () =>
+        evaluate(`
+          ntahinduka x = 1
+          x = 2
+        `),
+      KinRuntimeError,
+      {
+        ERRNAME: 'RuntimeError',
+        ERRCODE: 'E_RUNTIME',
+        message: 'Cannot reassign to variable "x" as it\'s constant.',
+      },
+    );
+  });
+});
+
+describe('catch can distinguish Kin error categories', () => {
+  test('a host catch can branch on ERRCODE', () => {
+    const seen: string[] = [];
+
+    const cases: Array<() => unknown> = [
+      () => new Lexer('~').tokenize(),
+      () => evaluate('ntabwo_iriho'),
+      () => evaluate('ubusa.foo'),
+      () =>
+        evaluate(`
+          reka x = 1
+          reka x = 2
+        `),
+    ];
+
+    for (const run of cases) {
+      try {
+        run();
+      } catch (error) {
+        if (!isKinError(error)) {
+          throw error;
+        }
+        switch (error.ERRCODE) {
+          case 'E_SYNTAX':
+            seen.push(error.ERRNAME);
+            break;
+          case 'E_REFERENCE':
+            seen.push(error.ERRNAME);
+            break;
+          case 'E_TYPE':
+            seen.push(error.ERRNAME);
+            break;
+          case 'E_RUNTIME':
+            seen.push(error.ERRNAME);
+            break;
+        }
+      }
+    }
+
+    expect(seen).toEqual([
+      'SyntaxError',
+      'ReferenceError',
+      'TypeError',
+      'RuntimeError',
+    ]);
+  });
+});

--- a/tests/helpers.ts
+++ b/tests/helpers.ts
@@ -1,6 +1,8 @@
+import { expect } from 'vitest';
 import Parser from '../src/parser/parser';
 import { Interpreter } from '../src/runtime/interpreter';
 import { createGlobalEnv } from '../src/runtime/globals';
+import { KinError, KinErrorCode, KinErrorName } from '../src/lib/errors';
 import {
   BooleanVal,
   NativeFnValue,
@@ -73,4 +75,35 @@ export function asObject(value: RuntimeVal): ObjectVal {
     throw new Error(`Expected object, got ${value.type}`);
   }
   return value as ObjectVal;
+}
+
+/** Assert that `fn` throws a Kin error of the given class with matching name/code. */
+export function expectKinError(
+  fn: () => unknown,
+  ErrorClass: new (message: string) => KinError,
+  expected: {
+    ERRNAME: KinErrorName;
+    ERRCODE: KinErrorCode;
+    message?: string | RegExp;
+  },
+): KinError {
+  let thrown: unknown;
+  try {
+    fn();
+  } catch (error) {
+    thrown = error;
+  }
+  expect(thrown, 'expected fn to throw a Kin error').toBeInstanceOf(ErrorClass);
+  const err = thrown as KinError;
+  expect(err.ERRNAME).toBe(expected.ERRNAME);
+  expect(err.ERRCODE).toBe(expected.ERRCODE);
+  expect(err.code).toBe(expected.ERRCODE);
+  if (expected.message !== undefined) {
+    if (typeof expected.message === 'string') {
+      expect(err.message).toContain(expected.message);
+    } else {
+      expect(err.message).toMatch(expected.message);
+    }
+  }
+  return err;
 }

--- a/tests/lexer.test.ts
+++ b/tests/lexer.test.ts
@@ -1,6 +1,7 @@
 import { describe, test, expect } from 'vitest';
 import TokenType from '../src/lexer/tokens';
 import Lexer from '../src/lexer/lexer';
+import { KinSyntaxError } from '../src/lib/errors';
 
 describe('Lexer', () => {
   test('should tokenize arithmetic expressions correctly', () => {
@@ -91,7 +92,8 @@ describe('Lexer', () => {
   });
   test('should handle errors for unexpected characters', () => {
     const lexer = new Lexer('let x = ~;');
-    expect(() => lexer.tokenize()).toThrowError(
+    expect(() => lexer.tokenize()).toThrow(KinSyntaxError);
+    expect(() => new Lexer('let x = ~;').tokenize()).toThrowError(
       "Unexpected character '~' at line 1",
     );
   });

--- a/tests/member-expression.test.ts
+++ b/tests/member-expression.test.ts
@@ -4,6 +4,7 @@ import Parser from '../src/parser/parser';
 import { Interpreter } from '../src/runtime/interpreter';
 import { createGlobalEnv } from '../src/runtime/globals';
 import { NumberVal } from '../src/runtime/values';
+import { KinTypeError } from '../src/lib/errors';
 
 describe('Member Expression (computed + dot access) Tests', () => {
   function evaluate(sourceCode: string) {
@@ -180,6 +181,12 @@ describe('Member Expression (computed + dot access) Tests', () => {
 
   describe('Error handling (Kin errors, not host TypeErrors)', () => {
     test('should throw a Kin error when a null is used as an index', () => {
+      expect(() =>
+        evaluate(`
+          reka arr = [1, 2]
+          arr[ubusa]
+        `),
+      ).toThrow(KinTypeError);
       expect(() =>
         evaluate(`
           reka arr = [1, 2]

--- a/tests/parser.test.ts
+++ b/tests/parser.test.ts
@@ -1,5 +1,7 @@
 import { describe, test, expect } from 'vitest';
 import Parser from '../src/parser/parser';
+import { KinSyntaxError } from '../src/lib/errors';
+import { expectKinError } from './helpers';
 
 describe('Parser', () => {
   test('should parse numeric and string literals in variable declaration', () => {
@@ -429,6 +431,9 @@ describe('Parser', () => {
   test('should handle syntax errors correctly', () => {
     const sourceCode = 'reka x = ;';
     const parser = new Parser();
-    expect(() => parser.produceAST(sourceCode)).toThrowError();
+    expectKinError(() => parser.produceAST(sourceCode), KinSyntaxError, {
+      ERRNAME: 'SyntaxError',
+      ERRCODE: 'E_SYNTAX',
+    });
   });
 });


### PR DESCRIPTION
## Kin Pull Request

**Summary of Changes**
Feature for #114. Kin no longer throws a generic host `Error` for every failure. Lexer, parser, and runtime now throw a small taxonomy of `KinError` subclasses, each with a stable `ERRNAME` and `ERRCODE` so host programs and tests can distinguish them.

**Description of Changes**
- Added `src/lib/errors.ts` with `KinError` and four subclasses:
  - `KinSyntaxError` — `ERRNAME: SyntaxError`, `ERRCODE: E_SYNTAX` (lexer / parser)
  - `KinTypeError` — `ERRNAME: TypeError`, `ERRCODE: E_TYPE` (bad index, property on a primitive, non-callable, arity/type checks)
  - `KinReferenceError` — `ERRNAME: ReferenceError`, `ERRCODE: E_REFERENCE` (unresolved name)
  - `KinRuntimeError` — `ERRNAME: RuntimeError`, `ERRCODE: E_RUNTIME` (redeclare, reassign const, other runtime failures)
- Wired throw sites in the lexer, parser, environment, expression evaluator, and native builtins.
- `LogError` now throws `KinRuntimeError`; native arity/type checks use `LogTypeError` (`KinTypeError`).
- CLI / REPL print `ERRNAME [ERRCODE]: message`. REPL also catches parse-time errors.
- Classes are exported from `@kin-lang/kin` along with `isKinError` and `formatKinError`.
- Existing error **messages are unchanged**, so current tests still match.

Host catch example:

```ts
try {
  Interpreter.evaluate(ast, env);
} catch (error) {
  if (isKinError(error) && error.ERRCODE === 'E_REFERENCE') {
    // missing variable
  }
}
```

**Testing**
- `npm test` — 7 files, 166 tests, all passing (including new `tests/errors.test.ts`)
- `npx eslint .` — clean
- `npm run build` — tsc succeeded

**Screenshots or Recordings**
N/A — CLI-only. Covered by unit tests that assert class, `ERRNAME`, and `ERRCODE`.

**Checklist**
* [x] I have performed a self-review of my code.
* [x] I have added thorough tests for any new features.
* [x] I have updated the documentation to reflect the changes made in this pull request.
* [ ] I have addressed any comments or questions raised by reviewers.

**Additional Notes**
Kept the taxonomy small on purpose: four categories, one code per class. No Kin-level try/catch syntax — the language still has no catch keyword. Host JS (and the CLI) can now distinguish errors by `instanceof`, `ERRNAME`, or `ERRCODE`.

Closes #114

**Thank you for contributing to Kin!**