### PR TITLE
feat: add KIN_URUSOBE native HTTP networking (#255)

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -168,6 +168,8 @@ env.declareVar(
 
 See the file for more examples and implementation details.
 
+**Networking:** `KIN_URUSOBE` (registered from [`src/runtime/network.ts`](src/runtime/network.ts)) exposes HTTP `kubona` (GET), `ohereza` (POST), and `saba` (any method). The HTTP transport is injectable so tests can mock requests without touching the live internet.
+
 ---
 
 ## 5. Adding Features & Contributing

--- a/examples/network.kin
+++ b/examples/network.kin
@@ -1,0 +1,30 @@
+# KIN_URUSOBE — native HTTP networking
+#
+#   KIN_URUSOBE.kubona(url)                     HTTP GET
+#   KIN_URUSOBE.kubona(url, imitwe)             GET with headers
+#   KIN_URUSOBE.ohereza(url, inyandiko)         HTTP POST (string or object body)
+#   KIN_URUSOBE.ohereza(url, inyandiko, imitwe) POST with headers
+#   KIN_URUSOBE.saba(uburyo, url, inyandiko?, imitwe?)
+#                                               any method (GET, POST, PUT, ...)
+#
+# Response object:
+#   imiterere   status code   (e.g. 200)
+#   ubutumwa    status text   (e.g. "OK")
+#   imitwe      headers       (object)
+#   inyandiko   body          (string)
+#
+# Live request (needs a network — do not run in CI):
+#   reka igisubizo = KIN_URUSOBE.kubona("https://example.com")
+#   tangaza_amakuru(igisubizo.imiterere)
+#   tangaza_amakuru(igisubizo.inyandiko)
+#
+#   reka yoherejwe = KIN_URUSOBE.ohereza(
+#       "https://example.com/api",
+#       { amazina: "Kin" }
+#   )
+#   tangaza_amakuru(yoherejwe.inyandiko)
+
+tangaza_amakuru("KIN_URUSOBE ", ubwoko(KIN_URUSOBE))
+tangaza_amakuru("kubona ", ubwoko(KIN_URUSOBE.kubona))
+tangaza_amakuru("ohereza ", ubwoko(KIN_URUSOBE.ohereza))
+tangaza_amakuru("saba ", ubwoko(KIN_URUSOBE.saba))

--- a/src/runtime/globals.ts
+++ b/src/runtime/globals.ts
@@ -29,6 +29,7 @@ import {
 } from 'fs';
 import path from 'path';
 import { LogError } from '../lib/log';
+import { createNetworkBuiltins } from './network';
 
 export function createGlobalEnv(filename: string): Environment {
   const env = new Environment();
@@ -624,6 +625,9 @@ export function createGlobalEnv(filename: string): Environment {
     ),
     true,
   );
+
+  // HTTP networking (GET / POST / generic request)
+  env.declareVar('KIN_URUSOBE', createNetworkBuiltins(), true);
 
   return env;
 }

--- a/src/runtime/network.ts
+++ b/src/runtime/network.ts
@@ -1,0 +1,332 @@
+/*************************************************************************************************************
+ *                                                  Network                                                  *
+ *     Native HTTP helpers for Kin. The transport is injectable so tests never touch the live internet.      *
+ *************************************************************************************************************/
+import { spawnSync } from 'child_process';
+import { LogError } from '../lib/log';
+import {
+  BooleanVal,
+  MK_NATIVE_FN,
+  MK_NUMBER,
+  MK_OBJECT,
+  MK_STRING,
+  NumberVal,
+  ObjectVal,
+  RuntimeVal,
+  StringVal,
+} from './values';
+
+export type HttpMethod = string;
+
+export type HttpRequest = {
+  method: HttpMethod;
+  url: string;
+  headers: Record<string, string>;
+  body?: string;
+};
+
+export type HttpResponse = {
+  status: number;
+  statusText: string;
+  headers: Record<string, string>;
+  body: string;
+};
+
+export type HttpTransport = (request: HttpRequest) => HttpResponse;
+
+const REQUEST_TIMEOUT_MS = 30_000;
+const MAX_RESPONSE_BYTES = 20 * 1024 * 1024;
+
+/**
+ * Child script: read one JSON HttpRequest from stdin, perform `fetch`,
+ * write one JSON HttpResponse to stdout. Kept as a string so the parent
+ * interpreter can stay synchronous (same pattern as `sisitemu` / execSync).
+ */
+const FETCH_SCRIPT = `
+let raw = '';
+process.stdin.setEncoding('utf8');
+process.stdin.on('data', (chunk) => { raw += chunk; });
+process.stdin.on('end', () => {
+  (async () => {
+    const req = JSON.parse(raw);
+    const init = {
+      method: req.method,
+      headers: req.headers || {},
+      signal: AbortSignal.timeout(${REQUEST_TIMEOUT_MS}),
+      redirect: 'follow',
+    };
+    const method = String(req.method || 'GET').toUpperCase();
+    if (req.body != null && req.body !== '' && method !== 'GET' && method !== 'HEAD') {
+      init.body = req.body;
+    }
+    const res = await fetch(req.url, init);
+    const headers = {};
+    res.headers.forEach((value, key) => { headers[key] = value; });
+    const body = await res.text();
+    process.stdout.write(JSON.stringify({
+      status: res.status,
+      statusText: res.statusText,
+      headers,
+      body,
+    }));
+  })().catch((err) => {
+    process.stderr.write(err && err.message ? err.message : String(err));
+    process.exit(1);
+  });
+});
+`;
+
+function defaultHttpTransport(request: HttpRequest): HttpResponse {
+  const result = spawnSync(process.execPath, ['-e', FETCH_SCRIPT], {
+    input: JSON.stringify(request),
+    encoding: 'utf-8',
+    maxBuffer: MAX_RESPONSE_BYTES,
+    timeout: REQUEST_TIMEOUT_MS + 5_000,
+    windowsHide: true,
+  });
+
+  if (result.error) {
+    throw new Error(result.error.message);
+  }
+
+  if (result.status !== 0) {
+    const detail = (result.stderr || result.stdout || 'request failed').trim();
+    throw new Error(detail || 'request failed');
+  }
+
+  try {
+    const parsed = JSON.parse(result.stdout) as HttpResponse;
+    return {
+      status: Number(parsed.status),
+      statusText: String(parsed.statusText ?? ''),
+      headers: parsed.headers ?? {},
+      body: String(parsed.body ?? ''),
+    };
+  } catch {
+    throw new Error('failed to parse HTTP response');
+  }
+}
+
+let httpTransport: HttpTransport = defaultHttpTransport;
+
+/** Replace the HTTP transport. Pass `null` to restore the default. */
+export function setHttpTransport(next: HttpTransport | null): void {
+  httpTransport = next ?? defaultHttpTransport;
+}
+
+export function getHttpTransport(): HttpTransport {
+  return httpTransport;
+}
+
+export function performHttpRequest(request: HttpRequest): HttpResponse {
+  return httpTransport(request);
+}
+
+function isHttpUrl(url: string): boolean {
+  try {
+    const parsed = new URL(url);
+    return parsed.protocol === 'http:' || parsed.protocol === 'https:';
+  } catch {
+    return false;
+  }
+}
+
+function requireStringArg(
+  fnName: string,
+  args: RuntimeVal[],
+  index: number,
+): string {
+  const arg = args[index];
+  if (!arg || arg.type !== 'string') {
+    LogError(`${fnName} expects argument ${index + 1} to be a string`);
+  }
+  return (arg as StringVal).value;
+}
+
+function requireUrl(fnName: string, args: RuntimeVal[], index: number): string {
+  const url = requireStringArg(fnName, args, index);
+  if (!isHttpUrl(url)) {
+    LogError(`${fnName} expects a valid http or https URL`);
+  }
+  return url;
+}
+
+function runtimeToJson(value: RuntimeVal): unknown {
+  switch (value.type) {
+    case 'string':
+      return (value as StringVal).value;
+    case 'number':
+      return (value as NumberVal).value;
+    case 'boolean':
+      return (value as BooleanVal).value;
+    case 'null':
+      return null;
+    case 'object': {
+      const obj = value as ObjectVal;
+      const keys = [...obj.properties.keys()];
+      const arrayLike =
+        keys.length > 0 && keys.every((key, i) => key === String(i));
+      if (arrayLike) {
+        return keys.map((key) => runtimeToJson(obj.properties.get(key)!));
+      }
+      const record: Record<string, unknown> = {};
+      for (const [key, nested] of obj.properties) {
+        record[key] = runtimeToJson(nested);
+      }
+      return record;
+    }
+    default:
+      return null;
+  }
+}
+
+function encodeBody(value: RuntimeVal): { body: string; contentType?: string } {
+  if (value.type === 'string') {
+    return { body: (value as StringVal).value };
+  }
+  if (value.type === 'null') {
+    return { body: '' };
+  }
+  if (value.type === 'object') {
+    return {
+      body: JSON.stringify(runtimeToJson(value)),
+      contentType: 'application/json',
+    };
+  }
+  if (value.type === 'number' || value.type === 'boolean') {
+    return { body: String((value as NumberVal | BooleanVal).value) };
+  }
+  LogError('KIN_URUSOBE expects the request body to be a string or object');
+  return { body: '' };
+}
+
+function headersFromRuntime(
+  fnName: string,
+  value: RuntimeVal,
+): Record<string, string> {
+  if (value.type !== 'object') {
+    LogError(`${fnName} expects headers to be an object`);
+  }
+  const headers: Record<string, string> = {};
+  for (const [key, nested] of (value as ObjectVal).properties) {
+    if (
+      nested.type === 'string' ||
+      nested.type === 'number' ||
+      nested.type === 'boolean'
+    ) {
+      headers[key] = String((nested as StringVal | NumberVal).value);
+    } else if (nested.type === 'null') {
+      continue;
+    } else {
+      LogError(`${fnName} expects header values to be strings`);
+    }
+  }
+  return headers;
+}
+
+function responseToRuntime(response: HttpResponse): RuntimeVal {
+  const headers = new Map<string, RuntimeVal>();
+  for (const [key, value] of Object.entries(response.headers)) {
+    headers.set(key, MK_STRING(String(value)));
+  }
+
+  return MK_OBJECT(
+    new Map<string, RuntimeVal>()
+      .set('imiterere', MK_NUMBER(response.status))
+      .set('ubutumwa', MK_STRING(response.statusText))
+      .set('imitwe', MK_OBJECT(headers))
+      .set('inyandiko', MK_STRING(response.body)),
+  );
+}
+
+function runRequest(fnName: string, request: HttpRequest): RuntimeVal {
+  try {
+    return responseToRuntime(performHttpRequest(request));
+  } catch (error: unknown) {
+    const message = error instanceof Error ? error.message : String(error);
+    LogError(`${fnName} failed: ${message}`);
+    return MK_STRING(message);
+  }
+}
+
+function mergeHeaders(
+  encoded: { contentType?: string },
+  userHeaders: Record<string, string>,
+): Record<string, string> {
+  const headers: Record<string, string> = { ...userHeaders };
+  const hasContentType = Object.keys(headers).some(
+    (key) => key.toLowerCase() === 'content-type',
+  );
+  if (encoded.contentType && !hasContentType) {
+    headers['content-type'] = encoded.contentType;
+  }
+  return headers;
+}
+
+export function createNetworkBuiltins(): RuntimeVal {
+  return MK_OBJECT(
+    new Map<string, RuntimeVal>()
+      .set(
+        'kubona',
+        MK_NATIVE_FN((args) => {
+          if (args.length < 1) {
+            LogError('KIN_URUSOBE.kubona expects at least one argument');
+          }
+          const url = requireUrl('KIN_URUSOBE.kubona', args, 0);
+          const headers =
+            args.length >= 2
+              ? headersFromRuntime('KIN_URUSOBE.kubona', args[1])
+              : {};
+          return runRequest('KIN_URUSOBE.kubona', {
+            method: 'GET',
+            url,
+            headers,
+          });
+        }),
+      )
+      .set(
+        'ohereza',
+        MK_NATIVE_FN((args) => {
+          if (args.length < 2) {
+            LogError('KIN_URUSOBE.ohereza expects at least two arguments');
+          }
+          const url = requireUrl('KIN_URUSOBE.ohereza', args, 0);
+          const encoded = encodeBody(args[1]);
+          const userHeaders =
+            args.length >= 3
+              ? headersFromRuntime('KIN_URUSOBE.ohereza', args[2])
+              : {};
+          return runRequest('KIN_URUSOBE.ohereza', {
+            method: 'POST',
+            url,
+            headers: mergeHeaders(encoded, userHeaders),
+            body: encoded.body,
+          });
+        }),
+      )
+      .set(
+        'saba',
+        MK_NATIVE_FN((args) => {
+          if (args.length < 2) {
+            LogError('KIN_URUSOBE.saba expects at least two arguments');
+          }
+          const method = requireStringArg('KIN_URUSOBE.saba', args, 0);
+          const url = requireUrl('KIN_URUSOBE.saba', args, 1);
+          const encoded =
+            args.length >= 3 && args[2].type !== 'null'
+              ? encodeBody(args[2])
+              : { body: '' };
+          const userHeaders =
+            args.length >= 4
+              ? headersFromRuntime('KIN_URUSOBE.saba', args[3])
+              : {};
+          return runRequest('KIN_URUSOBE.saba', {
+            method: method.toUpperCase(),
+            url,
+            headers: mergeHeaders(encoded, userHeaders),
+            body: encoded.body || undefined,
+          });
+        }),
+      ),
+  );
+}

--- a/tests/examples.test.ts
+++ b/tests/examples.test.ts
@@ -61,6 +61,7 @@ describe('Example programs (current language implementation)', () => {
         'loops.kin',
         'objects.kin',
         'switch.kin',
+        'network.kin',
       ]),
     );
   });

--- a/tests/globals.test.ts
+++ b/tests/globals.test.ts
@@ -722,6 +722,7 @@ describe('createGlobalEnv', () => {
         'KIN_URUTONDE',
         'ubwoko',
         'KIN_INYANDIKO',
+        'KIN_URUSOBE',
       ];
 
       for (const name of expected) {
@@ -761,6 +762,7 @@ describe('createGlobalEnv', () => {
           'siba_ahabanza',
         ],
         KIN_INYANDIKO: ['soma', 'andika', 'vugurura', 'siba'],
+        KIN_URUSOBE: ['kubona', 'ohereza', 'saba'],
       };
 
       for (const [objectName, keys] of Object.entries(methods)) {

--- a/tests/network.test.ts
+++ b/tests/network.test.ts
@@ -1,0 +1,246 @@
+import { afterEach, beforeEach, describe, expect, test } from 'vitest';
+import { HttpRequest, setHttpTransport } from '../src/runtime/network';
+import { createGlobalEnv } from '../src/runtime/globals';
+import { NativeFnValue, ObjectVal } from '../src/runtime/values';
+import {
+  asNumber,
+  asObject,
+  asString,
+  evaluate,
+  objectMethod,
+} from './helpers';
+
+type MockCall = HttpRequest;
+
+function mockTransport(
+  handler: (req: HttpRequest) => {
+    status?: number;
+    statusText?: string;
+    headers?: Record<string, string>;
+    body?: string;
+  },
+) {
+  const calls: MockCall[] = [];
+  setHttpTransport((req) => {
+    calls.push(req);
+    const res = handler(req);
+    return {
+      status: res.status ?? 200,
+      statusText: res.statusText ?? 'OK',
+      headers: res.headers ?? { 'content-type': 'text/plain' },
+      body: res.body ?? '',
+    };
+  });
+  return calls;
+}
+
+describe('KIN_URUSOBE', () => {
+  beforeEach(() => {
+    setHttpTransport(() => {
+      throw new Error(
+        'unexpected network call — tests must mock the transport',
+      );
+    });
+  });
+
+  afterEach(() => {
+    setHttpTransport(null);
+  });
+
+  test('registers kubona, ohereza, and saba on the global env', () => {
+    const env = createGlobalEnv('test.kin');
+    const net = env.lookupVar('KIN_URUSOBE') as ObjectVal;
+    expect(net.type).toBe('object');
+    for (const name of ['kubona', 'ohereza', 'saba']) {
+      expect(net.properties.get(name)?.type).toBe('native-fn');
+      expect((net.properties.get(name) as NativeFnValue).call).toBeTypeOf(
+        'function',
+      );
+    }
+  });
+
+  test('kubona performs an HTTP GET and returns the response object', () => {
+    const calls = mockTransport(() => ({
+      status: 200,
+      statusText: 'OK',
+      headers: { 'content-type': 'text/plain' },
+      body: 'muraho',
+    }));
+
+    const { result } = evaluate(
+      'KIN_URUSOBE.kubona("https://example.test/hello")',
+    );
+    const response = asObject(result);
+
+    expect(calls).toHaveLength(1);
+    expect(calls[0].method).toBe('GET');
+    expect(calls[0].url).toBe('https://example.test/hello');
+    expect(calls[0].body).toBeUndefined();
+
+    expect(asNumber(response.properties.get('imiterere')!)).toBe(200);
+    expect(asString(response.properties.get('ubutumwa')!)).toBe('OK');
+    expect(asString(response.properties.get('inyandiko')!)).toBe('muraho');
+    expect(
+      asString(
+        asObject(response.properties.get('imitwe')!).properties.get(
+          'content-type',
+        )!,
+      ),
+    ).toBe('text/plain');
+  });
+
+  test('kubona forwards an optional headers object', () => {
+    const calls = mockTransport(() => ({ body: 'ok' }));
+
+    evaluate(`
+      KIN_URUSOBE.kubona("https://example.test/h", {
+        Accept: "application/json",
+        XKin: "1"
+      })
+    `);
+
+    expect(calls[0].headers.Accept).toBe('application/json');
+    expect(calls[0].headers.XKin).toBe('1');
+  });
+
+  test('ohereza POSTs a string body', () => {
+    const calls = mockTransport(() => ({ status: 201, body: 'created' }));
+
+    const { result } = evaluate(
+      'KIN_URUSOBE.ohereza("https://example.test/items", "payload")',
+    );
+
+    expect(calls[0].method).toBe('POST');
+    expect(calls[0].url).toBe('https://example.test/items');
+    expect(calls[0].body).toBe('payload');
+    expect(asNumber(asObject(result).properties.get('imiterere')!)).toBe(201);
+    expect(asString(asObject(result).properties.get('inyandiko')!)).toBe(
+      'created',
+    );
+  });
+
+  test('ohereza JSON-encodes an object body and sets content-type', () => {
+    const calls = mockTransport(() => ({ body: '{}' }));
+
+    evaluate(
+      'KIN_URUSOBE.ohereza("https://example.test/json", { amazina: "Kin", umubare: 2 })',
+    );
+
+    expect(calls[0].method).toBe('POST');
+    expect(JSON.parse(calls[0].body ?? '')).toEqual({
+      amazina: 'Kin',
+      umubare: 2,
+    });
+    expect(calls[0].headers['content-type']).toBe('application/json');
+  });
+
+  test('ohereza does not override a caller-supplied content-type', () => {
+    const calls = mockTransport(() => ({ body: 'ok' }));
+    const env = createGlobalEnv('test.kin');
+    const post = objectMethod(env, 'KIN_URUSOBE', 'ohereza');
+    const headers = new Map();
+    headers.set('content-type', {
+      type: 'string',
+      value: 'application/vnd.kin+json',
+    });
+
+    post.call(
+      [
+        { type: 'string', value: 'https://example.test/json' },
+        {
+          type: 'object',
+          properties: new Map([['amazina', { type: 'string', value: 'Kin' }]]),
+        },
+        { type: 'object', properties: headers },
+      ] as never,
+      env,
+    );
+
+    expect(calls[0].headers['content-type']).toBe('application/vnd.kin+json');
+  });
+
+  test('saba sends a caller-chosen method', () => {
+    const calls = mockTransport(() => ({ status: 204, body: '' }));
+
+    evaluate('KIN_URUSOBE.saba("put", "https://example.test/item", "next")');
+
+    expect(calls[0].method).toBe('PUT');
+    expect(calls[0].body).toBe('next');
+    expect(calls[0].url).toBe('https://example.test/item');
+  });
+
+  test('HTTP error status codes are returned, not thrown', () => {
+    mockTransport(() => ({
+      status: 404,
+      statusText: 'Not Found',
+      body: 'missing',
+    }));
+
+    const { result } = evaluate(
+      'KIN_URUSOBE.kubona("https://example.test/missing")',
+    );
+    expect(asNumber(asObject(result).properties.get('imiterere')!)).toBe(404);
+    expect(asString(asObject(result).properties.get('inyandiko')!)).toBe(
+      'missing',
+    );
+  });
+
+  test('network failures become clear Kin errors', () => {
+    setHttpTransport(() => {
+      throw new Error('getaddrinfo ENOTFOUND example.test');
+    });
+
+    expect(() =>
+      evaluate('KIN_URUSOBE.kubona("https://example.test/")'),
+    ).toThrow('KIN_URUSOBE.kubona failed: getaddrinfo ENOTFOUND example.test');
+  });
+
+  test('rejects missing and invalid arguments', () => {
+    mockTransport(() => ({ body: '' }));
+
+    expect(() => evaluate('KIN_URUSOBE.kubona()')).toThrow(
+      'KIN_URUSOBE.kubona expects at least one argument',
+    );
+    expect(() => evaluate('KIN_URUSOBE.kubona(1)')).toThrow(
+      'KIN_URUSOBE.kubona expects argument 1 to be a string',
+    );
+    expect(() => evaluate('KIN_URUSOBE.kubona("ftp://example.test")')).toThrow(
+      'KIN_URUSOBE.kubona expects a valid http or https URL',
+    );
+    expect(() => evaluate('KIN_URUSOBE.kubona("not-a-url")')).toThrow(
+      'KIN_URUSOBE.kubona expects a valid http or https URL',
+    );
+    expect(() =>
+      evaluate('KIN_URUSOBE.ohereza("https://example.test")'),
+    ).toThrow('KIN_URUSOBE.ohereza expects at least two arguments');
+    expect(() => evaluate('KIN_URUSOBE.saba("GET")')).toThrow(
+      'KIN_URUSOBE.saba expects at least two arguments',
+    );
+  });
+
+  test('does not invoke the real transport when mocked (no live internet)', () => {
+    let called = false;
+    setHttpTransport((req) => {
+      called = true;
+      expect(req.url.startsWith('https://')).toBe(true);
+      return {
+        status: 200,
+        statusText: 'OK',
+        headers: {},
+        body: 'stub',
+      };
+    });
+
+    const env = createGlobalEnv('test.kin');
+    const get = objectMethod(env, 'KIN_URUSOBE', 'kubona');
+    const result = get.call(
+      [{ type: 'string', value: 'https://example.test' } as never],
+      env,
+    );
+
+    expect(called).toBe(true);
+    expect(asString(asObject(result).properties.get('inyandiko')!)).toBe(
+      'stub',
+    );
+  });
+});


### PR DESCRIPTION
## Kin Pull Request

**Summary of Changes**
Adds a first-cut native networking namespace, `KIN_URUSOBE`, so Kin programs can make HTTP requests. Closes #255.

**Description of Changes**
- New built-in object `KIN_URUSOBE` registered in the global environment, matching existing namespaces (`KIN_INYANDIKO`, `KIN_IMIBARE`, …).
- Methods:
  - `kubona(url, headers?)` — HTTP GET
  - `ohereza(url, body, headers?)` — HTTP POST; a string body is sent as-is, an object is JSON-encoded
  - `saba(method, url, body?, headers?)` — any HTTP method
- Responses are Kin objects: `imiterere` (status), `ubutumwa` (status text), `imitwe` (headers), `inyandiko` (body).
- Network/transport failures throw clear Kin errors via `LogError`. HTTP error status codes (404, 500, …) are returned, not thrown.
- Implementation uses Node built-ins only (`fetch` in a synchronous child process, same blocking style as `sisitemu`). No new npm dependencies.
- HTTP transport is injectable (`setHttpTransport`) so tests mock the network and never hit the live internet.
- Example program: `examples/network.kin` (documents the API; does not perform a live request).

**Testing**
- New `tests/network.test.ts` covers GET/POST/JSON/headers, generic methods, validation, HTTP error statuses, and mocked transport failures.
- Existing globals/examples tests updated for the new namespace.
- `npm test` — 160 passed
- `npm run lint` — clean
- `npm run build` — clean

**Screenshots or Recordings**
N/A

**Checklist**

* [x] I have performed a self-review of my code.
* [x] I have added thorough tests for any new features.
* [x] I have updated the documentation to reflect the changes made in this pull request.
* [x] I have addressed any comments or questions raised by reviewers.

**Additional Notes**
TCP/UDP sockets are left for a follow-up. This PR is intentionally scoped to HTTP GET/POST (plus a generic `saba`) as a scalable first implementation.

**Thank you for contributing to Kin!**