### PR TITLE
feat: multi-file imports with injiza()

### DIFF
--- a/README.md
+++ b/README.md
@@ -168,6 +168,21 @@ tangaza_amakuru(arr.ingano())          # method form
 tangaza_amakuru(KIN_URUTONDE.ifite(arr, 20))  # nibyo
 ```
 
+### Importing other files
+
+Use `injiza("path.kin")` to load another Kin file into the **same** environment. Variables and functions declared in the imported file become available after the call. Paths are resolved relative to the file that contains `injiza`. Each file is loaded once per run (re-import is a no-op). Circular imports raise an error.
+
+```Kin
+# utils.kin
+porogaramu_ntoya ongera(a, b) {
+  tanga a + b
+}
+
+# main.kin
+injiza("utils.kin")
+tangaza_amakuru(ongera(2, 3))  # 5
+```
+
 ### Checking a file without running it
 
 ```shell

--- a/README.md
+++ b/README.md
@@ -170,7 +170,7 @@ tangaza_amakuru(KIN_URUTONDE.ifite(arr, 20))  # nibyo
 
 ### Importing other files
 
-Use `injiza("path.kin")` to load another Kin file into the **same** environment. Variables and functions declared in the imported file become available after the call. Paths are resolved relative to the file that contains `injiza`. Each file is loaded once per run (re-import is a no-op). Circular imports raise an error.
+Use `injiza("path.kin")` to load another Kin file into the **program (global) environment**. Variables and functions declared at the top level of the imported file become available everywhere after the call — including when `injiza` is invoked from inside a function, `niba`, or loop. Paths are resolved relative to the file that contains `injiza`. Each file is loaded once per run (re-import is a no-op). Circular imports raise an error. Two files that declare the same name raise `K007`.
 
 ```Kin
 # utils.kin
@@ -183,13 +183,15 @@ injiza("utils.kin")
 tangaza_amakuru(ongera(2, 3))  # 5
 ```
 
+Embedders running a file should wrap evaluation with `withCurrentFile` (exported from `@kin-lang/kin`) so nested relative paths resolve correctly — the CLI already does this.
+
 ### Checking a file without running it
 
 ```shell
 kin check path/to/program.kin
 ```
 
-Reports all parse diagnostics (with line, column, and a caret) and exits non-zero when there are errors. Useful for teachers and CI.
+Reports parse diagnostics for **that single file** (with line, column, and a caret) and exits non-zero when there are errors. It does **not** follow `injiza()` imports — use `kin run` to surface errors inside dependencies. Useful for teachers and CI on individual files.
 
 ## Fun fact!
 

--- a/README.md
+++ b/README.md
@@ -172,6 +172,7 @@ tangaza_amakuru(KIN_URUTONDE.ifite(arr, 20))  # nibyo
 
 Use `injiza("path.kin")` to load another Kin file into the **program (global) environment**. Variables and functions declared at the top level of the imported file become available everywhere after the call — including when `injiza` is invoked from inside a function, `niba`, or loop. Paths are resolved relative to the file that contains `injiza`. Each file is loaded once per run (re-import is a no-op). Circular imports raise an error. Two files that declare the same name raise `K007`.
 
+If an import fails mid-file, **top-level name bindings** introduced during that import (including nested successful `injiza`s under it) are rolled back and those paths may be loaded again. Rollback is **not** deep: mutations to existing objects/arrays and host side effects (prints, file I/O) are not undone.
 ```Kin
 # utils.kin
 porogaramu_ntoya ongera(a, b) {

--- a/bin/kin.ts
+++ b/bin/kin.ts
@@ -10,8 +10,8 @@ import {
   createGlobalEnv,
   isKinError,
   renderThrown,
+  withCurrentFile,
 } from '../src/index';
-import { withCurrentFile } from '../src/runtime/path-resolve';
 import * as readline from 'readline/promises';
 
 const rl = readline.createInterface({
@@ -119,7 +119,9 @@ program
 
 program
   .command('check <file_location>')
-  .description('Parse a file and report diagnostics without executing.')
+  .description(
+    'Parse a single file and report diagnostics without executing. Does not follow injiza() imports.',
+  )
   .action(async (file_location) => {
     let source_codes = '';
     try {

--- a/bin/kin.ts
+++ b/bin/kin.ts
@@ -3,6 +3,7 @@
 import { program } from 'commander';
 import pkg from '../package.json';
 import { readFile } from 'fs/promises';
+import path from 'path';
 import {
   Interpreter,
   Parser,
@@ -10,6 +11,7 @@ import {
   isKinError,
   renderThrown,
 } from '../src/index';
+import { withCurrentFile } from '../src/runtime/path-resolve';
 import * as readline from 'readline/promises';
 
 const rl = readline.createInterface({
@@ -94,8 +96,11 @@ program
         }
         process.exit(1);
       }
+      const absolute = path.resolve(file_location);
       const env = createGlobalEnv(file_location);
-      Interpreter.evaluate(ast, env);
+      withCurrentFile(absolute, () => {
+        Interpreter.evaluate(ast, env);
+      });
       process.exit(0);
     } catch (error: unknown) {
       if (

--- a/docs/errors.md
+++ b/docs/errors.md
@@ -49,5 +49,7 @@ Host programs can branch on `instanceof`, `ERRNAME`, or `ERRCODE`.
 | K029 | RuntimeError | Unhandled type in equality | internal | Report to Kin developers. |
 | K030 | SyntaxError | Expected function name following porogaramu_ntoya | `porogaramu_ntoya (){}` | Name the function. |
 | K031 | SyntaxError | Variable name expected following reka or ntahinduka | `reka = 1` | Write `reka name = ...`. |
+| K032 | RuntimeError | Cannot import '{path}': file not found | `injiza("missing.kin")` | Check the path relative to the current file. |
+| K033 | RuntimeError | Circular import detected for '{path}' | A imports B imports A | Break the import cycle. |
 
 Messages are loaded from `src/messages/rw.json` (default) and `src/messages/en.json` (`KIN_LANG=en`).

--- a/examples/imports/main.kin
+++ b/examples/imports/main.kin
@@ -1,0 +1,8 @@
+# Multi-file import example (issue #169)
+# Run: kin run examples/imports/main.kin
+
+injiza("utils.kin")
+
+tangaza_amakuru(muraho("Kin"))
+tangaza_amakuru("2 + 3 = ", ongera(2, 3))
+tangaza_amakuru("utils version: ", VERSIYO)

--- a/examples/imports/utils.kin
+++ b/examples/imports/utils.kin
@@ -1,0 +1,11 @@
+# Shared helpers for the multi-file import example.
+
+porogaramu_ntoya ongera(a, b) {
+  tanga a + b
+}
+
+porogaramu_ntoya muraho(izina) {
+  tanga "Muraho, " + izina + "!"
+}
+
+reka VERSIYO = 1

--- a/grammar.bnf
+++ b/grammar.bnf
@@ -193,10 +193,10 @@ stringLiteral ::= '"' { anyCharacterExceptQuoteOrNewline } '"'
 ; Built-in functions (identifiers, not keywords) include:
 ;   tangaza_amakuru  injiza_amakuru  injiza  sisitemu  ubwoko
 ;
-; injiza("path.kin") loads another source file into the current
-; environment (bindings are shared). Paths are relative to the file
-; that contains the call. Each absolute path is loaded once per run;
-; circular imports raise K033.
+; injiza("path.kin") loads another source file into the program
+; (global) environment. Paths are relative to the file that contains
+; the call. Each absolute path is loaded once per run; circular
+; imports raise K033. Failed imports roll back partial declarations.
 
 ; ========================================
 ; Unused tokens  (lexer only — not in this grammar)

--- a/grammar.bnf
+++ b/grammar.bnf
@@ -189,6 +189,14 @@ stringLiteral ::= '"' { anyCharacterExceptQuoteOrNewline } '"'
 ; subiramo_niba  hagarara  komeza
 ; niba  nanone_niba  niba_byanze
 ; gereranya  usanze  ibindi
+;
+; Built-in functions (identifiers, not keywords) include:
+;   tangaza_amakuru  injiza_amakuru  injiza  sisitemu  ubwoko
+;
+; injiza("path.kin") loads another source file into the current
+; environment (bindings are shared). Paths are relative to the file
+; that contains the call. Each absolute path is loaded once per run;
+; circular imports raise K033.
 
 ; ========================================
 ; Unused tokens  (lexer only — not in this grammar)

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@kin-lang/kin",
-  "version": "0.4.3",
+  "version": "0.5.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@kin-lang/kin",
-      "version": "0.4.3",
+      "version": "0.5.0",
       "license": "MIT",
       "dependencies": {
         "chalk": "^6.0.0",

--- a/src/index.ts
+++ b/src/index.ts
@@ -38,6 +38,11 @@ import {
   CODE_CATEGORY,
 } from './lib/errors';
 import { renderKinError, renderThrown } from './lib/render-error';
+import {
+  resolveEntryFilename,
+  resolveKinPath,
+  withCurrentFile,
+} from './runtime/path-resolve';
 
 export {
   Parser,
@@ -69,6 +74,9 @@ export {
   CODE_CATEGORY,
   renderKinError,
   renderThrown,
+  resolveEntryFilename,
+  resolveKinPath,
+  withCurrentFile,
 };
 
 export type {

--- a/src/lib/errors.ts
+++ b/src/lib/errors.ts
@@ -86,6 +86,13 @@ export interface KinErrorOptions {
   cause?: unknown;
   /** Override the resolved message (rare; prefer catalog keys). */
   message?: string;
+  /**
+   * Source text the span refers to (e.g. an imported file).
+   * When set, renderers prefer this over the entry-file buffer.
+   */
+  source?: string;
+  /** Path shown in code frames when this error is rendered. */
+  filename?: string;
 }
 
 /**
@@ -93,6 +100,7 @@ export interface KinErrorOptions {
  * - `code` — stable detail code (K001, ...)
  * - `ERRNAME` / `ERRCODE` — category for host programs and tests
  * - optional source `span` and interpolation `params`
+ * - optional `source` / `filename` for multi-file attribution
  *
  * Prefer `createKinError` / `kinError` so the correct subclass is used.
  */
@@ -102,6 +110,8 @@ export class KinError extends Error {
   readonly ERRCODE: KinErrorCategoryCode;
   readonly span?: Span;
   readonly params: Record<string, string | number>;
+  readonly source?: string;
+  readonly filename?: string;
 
   constructor(
     code: string,
@@ -122,6 +132,8 @@ export class KinError extends Error {
     this.code = code;
     this.span = options.span;
     this.params = params;
+    this.source = options.source;
+    this.filename = options.filename;
     Object.setPrototypeOf(this, new.target.prototype);
   }
 }

--- a/src/lib/errors.ts
+++ b/src/lib/errors.ts
@@ -72,6 +72,8 @@ export const CODE_CATEGORY: Readonly<Record<string, KinErrorName>> = {
   K027: 'RuntimeError',
   K028: 'RuntimeError',
   K029: 'RuntimeError',
+  K032: 'RuntimeError',
+  K033: 'RuntimeError',
 };
 
 export function categoryForCode(code: string): KinErrorName {

--- a/src/lib/render-error.ts
+++ b/src/lib/render-error.ts
@@ -47,14 +47,16 @@ export function renderKinError(
   const lines: string[] = [header];
 
   const span = error.span;
-  const filename = options.filename ?? 'program.kin';
+  // Prefer attribution attached on the error (e.g. imported file) over entry options.
+  const filename = error.filename ?? options.filename ?? 'program.kin';
+  const source = error.source ?? options.source;
 
   if (span) {
     lines.push(` ${cyan('-->')} ${filename}:${span.line}:${span.column}`);
   }
 
-  if (span && options.source && hasSourceRange(span)) {
-    const sourceLines = options.source.split(/\r?\n/);
+  if (span && source && hasSourceRange(span)) {
+    const sourceLines = source.split(/\r?\n/);
     const lineText = sourceLines[span.line - 1] ?? '';
     const lineNo = String(span.line);
     const gutter = ' '.repeat(lineNo.length);

--- a/src/messages/en.json
+++ b/src/messages/en.json
@@ -29,5 +29,7 @@
   "K028": "Unknown operator '{op}'",
   "K029": "Unhandled type in equality: {type}",
   "K030": "Expected function name following porogaramu_ntoya",
-  "K031": "Variable name expected following reka or ntahinduka"
+  "K031": "Variable name expected following reka or ntahinduka",
+  "K032": "Cannot import '{path}': file not found",
+  "K033": "Circular import detected for '{path}'"
 }

--- a/src/messages/rw.json
+++ b/src/messages/rw.json
@@ -29,5 +29,7 @@
   "K028": "Ikimenyetso kitazwi '{op}'",
   "K029": "Ubwoko butazwi mu kugereranya: {type}",
   "K030": "Byari biteganyijwe izina rya porogaramu_ntoya",
-  "K031": "Byari biteganyijwe izina ry'ihinduragaciro nyuma ya reka cyangwa ntahinduka"
+  "K031": "Byari biteganyijwe izina ry'ihinduragaciro nyuma ya reka cyangwa ntahinduka",
+  "K032": "Ntibishobora kwinjiza '{path}': dosiye ntabwo ibonetse",
+  "K033": "Kwinjiza gahunda (circular import) kuri '{path}'"
 }

--- a/src/runtime/environment.ts
+++ b/src/runtime/environment.ts
@@ -35,6 +35,35 @@ export default class Environment {
     return this.parent ? this.parent.getRoot() : this;
   }
 
+  /**
+   * Snapshot this environment's own bindings (not parent scopes).
+   * Used by `injiza` to roll back partial declarations if an import fails.
+   */
+  public captureLocals(): {
+    variables: Map<string, RuntimeVal>;
+    constants: Set<string>;
+  } {
+    return {
+      variables: new Map(this.variables),
+      constants: new Set(this.constants),
+    };
+  }
+
+  /** Restore bindings previously returned by `captureLocals`. */
+  public restoreLocals(snapshot: {
+    variables: Map<string, RuntimeVal>;
+    constants: Set<string>;
+  }): void {
+    this.variables.clear();
+    this.constants.clear();
+    for (const [name, value] of snapshot.variables) {
+      this.variables.set(name, value);
+    }
+    for (const name of snapshot.constants) {
+      this.constants.add(name);
+    }
+  }
+
   public declareVar(
     varname: string,
     value: RuntimeVal,

--- a/src/runtime/environment.ts
+++ b/src/runtime/environment.ts
@@ -30,6 +30,11 @@ export default class Environment {
     this.constants = new Set();
   }
 
+  /** Walk to the outermost environment (global / entry scope). */
+  public getRoot(): Environment {
+    return this.parent ? this.parent.getRoot() : this;
+  }
+
   public declareVar(
     varname: string,
     value: RuntimeVal,

--- a/src/runtime/globals.ts
+++ b/src/runtime/globals.ts
@@ -7,6 +7,7 @@ import { MK_BOOL, MK_NULL, MK_STRING } from './values';
 import Environment from './environment';
 import {
   hagarara,
+  injiza,
   injiza_amakuru,
   sisitemu,
   tangaza_amakuru,
@@ -30,6 +31,8 @@ export function createGlobalEnv(filename: string): Environment {
   env.declareVar('tangaza_amakuru', tangaza_amakuru, true);
   env.declareVar('sisitemu', sisitemu, true);
   env.declareVar('injiza_amakuru', injiza_amakuru, true);
+  // Load and run another .kin file; bindings are shared with the caller.
+  env.declareVar('injiza', injiza, true);
   // Process exit. Named hagarara in the env; the lexer keyword shadows it
   // in source, so it is only reachable via the JS API.
   env.declareVar('hagarara', hagarara, true);

--- a/src/runtime/in-built/files.ts
+++ b/src/runtime/in-built/files.ts
@@ -4,18 +4,13 @@ import {
   appendFileSync,
   unlinkSync as deleteFileSync,
 } from 'fs';
-import path from 'path';
 import Environment from '../environment';
 import { MK_BOOL, MK_OBJECT, MK_STRING, ObjectVal, StringVal } from '../values';
 import { defineNative } from '../native';
+import { resolveKinPath } from '../path-resolve';
 
 function filePathFrom(env: Environment, relative: string): string {
-  return path.join(
-    path.dirname(
-      path.join(process.cwd(), (env.lookupVar('filename') as StringVal).value),
-    ),
-    relative,
-  );
+  return resolveKinPath(env, relative);
 }
 
 /** KIN_INYANDIKO — file I/O relative to the running script. */

--- a/src/runtime/in-built/io/index.ts
+++ b/src/runtime/in-built/io/index.ts
@@ -1,4 +1,5 @@
 export { tangaza_amakuru } from './tangaza_amakuru';
 export { sisitemu } from './sisitemu';
 export { injiza_amakuru } from './injiza_amakuru';
+export { injiza } from './injiza';
 export { hagarara } from './hagarara';

--- a/src/runtime/in-built/io/injiza.ts
+++ b/src/runtime/in-built/io/injiza.ts
@@ -1,0 +1,117 @@
+/*************************************************************************************************************
+ *                                                   injiza                                                  *
+ *  Load and run another .kin file in the caller's environment so its bindings become available.             *
+ *  Each absolute path is evaluated at most once per global environment (load-once). Circular imports throw. *
+ *************************************************************************************************************/
+
+import { existsSync, readFileSync } from 'fs';
+import path from 'path';
+import Parser from '../../../parser/parser';
+import { createKinError } from '../../../lib/errors';
+import Environment from '../../environment';
+import { Interpreter } from '../../interpreter';
+import { defineNative } from '../../native';
+import {
+  resolveEntryFilename,
+  resolveKinPath,
+  withCurrentFile,
+} from '../../path-resolve';
+import { MK_NULL, NativeFnValue, StringVal } from '../../values';
+
+/** Absolute paths already fully evaluated for a given root environment. */
+const loadedByRoot = new WeakMap<Environment, Set<string>>();
+
+/** Absolute paths currently mid-evaluation (for cycle detection). */
+const loadingByRoot = new WeakMap<Environment, Set<string>>();
+
+function loadedSet(root: Environment): Set<string> {
+  let set = loadedByRoot.get(root);
+  if (!set) {
+    set = new Set();
+    loadedByRoot.set(root, set);
+  }
+  return set;
+}
+
+function loadingSet(root: Environment): Set<string> {
+  let set = loadingByRoot.get(root);
+  if (!set) {
+    set = new Set();
+    loadingByRoot.set(root, set);
+  }
+  return set;
+}
+
+/**
+ * Ensure the entry script is on the loaded set so a file cannot injiza itself
+ * as a "fresh" load after already running as the entry point.
+ */
+function ensureEntrySeeded(root: Environment): void {
+  const loaded = loadedSet(root);
+  const entry = resolveEntryFilename(root);
+  // Only seed when we are evaluating under that entry file (not REPL cwd alone).
+  if (existsSync(entry) && entry.endsWith('.kin')) {
+    loaded.add(entry);
+  }
+}
+
+export const injiza: NativeFnValue = defineNative({
+  name: 'injiza',
+  params: ['string'],
+  maxArgs: 1,
+  fn: (args, env) => {
+    const requested = (args[0] as StringVal).value;
+    const absolute = path.normalize(resolveKinPath(env, requested));
+    const root = env.getRoot();
+
+    ensureEntrySeeded(root);
+
+    const loaded = loadedSet(root);
+    if (loaded.has(absolute)) {
+      return MK_NULL();
+    }
+
+    const loading = loadingSet(root);
+    if (loading.has(absolute)) {
+      throw createKinError('K033', {
+        params: { path: requested },
+        message: `Circular import detected for '${requested}'`,
+      });
+    }
+
+    if (!existsSync(absolute)) {
+      throw createKinError('K032', {
+        params: { path: requested },
+        message: `Cannot import '${requested}': file not found`,
+      });
+    }
+
+    let source: string;
+    try {
+      source = readFileSync(absolute, 'utf-8');
+    } catch (error: unknown) {
+      throw createKinError('K032', {
+        params: { path: requested },
+        message: `Cannot import '${requested}': file not found`,
+        cause: error,
+      });
+    }
+
+    loading.add(absolute);
+    try {
+      const parser = new Parser();
+      const ast = parser.produceAST(source);
+
+      // Same environment: declarations and functions in the imported file
+      // become visible to the caller (and vice versa for free variables).
+      const result = withCurrentFile(absolute, () =>
+        Interpreter.evaluate(ast, env),
+      );
+
+      loaded.add(absolute);
+      return result;
+    } finally {
+      loading.delete(absolute);
+    }
+  },
+});

--- a/src/runtime/in-built/io/injiza.ts
+++ b/src/runtime/in-built/io/injiza.ts
@@ -1,13 +1,13 @@
 /*************************************************************************************************************
  *                                                   injiza                                                  *
- *  Load and run another .kin file in the caller's environment so its bindings become available.             *
+ *  Load and run another .kin file in the program (root) environment so its bindings become available.       *
  *  Each absolute path is evaluated at most once per global environment (load-once). Circular imports throw. *
  *************************************************************************************************************/
 
-import { existsSync, readFileSync } from 'fs';
+import { existsSync, readFileSync, statSync } from 'fs';
 import path from 'path';
 import Parser from '../../../parser/parser';
-import { createKinError } from '../../../lib/errors';
+import { createKinError, isKinError } from '../../../lib/errors';
 import Environment from '../../environment';
 import { Interpreter } from '../../interpreter';
 import { defineNative } from '../../native';
@@ -43,16 +43,39 @@ function loadingSet(root: Environment): Set<string> {
 }
 
 /**
- * Ensure the entry script is on the loaded set so a file cannot injiza itself
- * as a "fresh" load after already running as the entry point.
+ * Mark the entry script as already loaded so self-injiza of the entry file
+ * is a no-op (does not re-run and redeclare bindings).
+ * Seeds any real file path, regardless of extension.
  */
 function ensureEntrySeeded(root: Environment): void {
   const loaded = loadedSet(root);
-  const entry = resolveEntryFilename(root);
-  // Only seed when we are evaluating under that entry file (not REPL cwd alone).
-  if (existsSync(entry) && entry.endsWith('.kin')) {
-    loaded.add(entry);
+  const entry = path.resolve(resolveEntryFilename(root));
+  try {
+    if (existsSync(entry) && statSync(entry).isFile()) {
+      loaded.add(entry);
+    }
+  } catch {
+    // Ignore races / permission errors; import will fail later if needed.
   }
+}
+
+/** Attach the imported file's source buffer so CLI frames point at the dependency. */
+function withImportContext(
+  error: unknown,
+  source: string,
+  filename: string,
+): never {
+  if (isKinError(error)) {
+    throw createKinError(error.code, {
+      span: error.span,
+      params: error.params,
+      message: error.message,
+      cause: error,
+      source,
+      filename,
+    });
+  }
+  throw error;
 }
 
 export const injiza: NativeFnValue = defineNative({
@@ -61,7 +84,7 @@ export const injiza: NativeFnValue = defineNative({
   maxArgs: 1,
   fn: (args, env) => {
     const requested = (args[0] as StringVal).value;
-    const absolute = path.normalize(resolveKinPath(env, requested));
+    const absolute = path.resolve(resolveKinPath(env, requested));
     const root = env.getRoot();
 
     ensureEntrySeeded(root);
@@ -88,8 +111,15 @@ export const injiza: NativeFnValue = defineNative({
 
     let source: string;
     try {
+      if (!statSync(absolute).isFile()) {
+        throw createKinError('K032', {
+          params: { path: requested },
+          message: `Cannot import '${requested}': file not found`,
+        });
+      }
       source = readFileSync(absolute, 'utf-8');
     } catch (error: unknown) {
+      if (isKinError(error)) throw error;
       throw createKinError('K032', {
         params: { path: requested },
         message: `Cannot import '${requested}': file not found`,
@@ -97,19 +127,31 @@ export const injiza: NativeFnValue = defineNative({
       });
     }
 
+    // Snapshot program bindings so a failed import does not leave partial
+    // declarations that would break a later re-import (K007).
+    const snapshot = root.captureLocals();
     loading.add(absolute);
     try {
       const parser = new Parser();
-      const ast = parser.produceAST(source);
+      let ast;
+      try {
+        ast = parser.produceAST(source);
+      } catch (error: unknown) {
+        withImportContext(error, source, absolute);
+      }
 
-      // Same environment: declarations and functions in the imported file
-      // become visible to the caller (and vice versa for free variables).
-      const result = withCurrentFile(absolute, () =>
-        Interpreter.evaluate(ast, env),
-      );
-
-      loaded.add(absolute);
-      return result;
+      // Always evaluate in the root/program environment so nested call sites
+      // (functions, niba, loops) still install shared top-level bindings.
+      try {
+        const result = withCurrentFile(absolute, () =>
+          Interpreter.evaluate(ast, root),
+        );
+        loaded.add(absolute);
+        return result;
+      } catch (error: unknown) {
+        root.restoreLocals(snapshot);
+        withImportContext(error, source, absolute);
+      }
     } finally {
       loading.delete(absolute);
     }

--- a/src/runtime/in-built/io/injiza.ts
+++ b/src/runtime/in-built/io/injiza.ts
@@ -59,7 +59,10 @@ function ensureEntrySeeded(root: Environment): void {
   }
 }
 
-/** Attach the imported file's source buffer so CLI frames point at the dependency. */
+/**
+ * Attach the imported file's source buffer so CLI frames point at the dependency.
+ * Preserve attribution already set by a nested import (do not re-stamp outer files).
+ */
 function withImportContext(
   error: unknown,
   source: string,
@@ -71,11 +74,19 @@ function withImportContext(
       params: error.params,
       message: error.message,
       cause: error,
-      source,
-      filename,
+      source: error.source ?? source,
+      filename: error.filename ?? filename,
     });
   }
   throw error;
+}
+
+/** Replace the contents of `target` with those of `snapshot`. */
+function restoreSet(target: Set<string>, snapshot: Set<string>): void {
+  target.clear();
+  for (const value of snapshot) {
+    target.add(value);
+  }
 }
 
 export const injiza: NativeFnValue = defineNative({
@@ -127,9 +138,12 @@ export const injiza: NativeFnValue = defineNative({
       });
     }
 
-    // Snapshot program bindings so a failed import does not leave partial
-    // declarations that would break a later re-import (K007).
+    // Snapshot program bindings AND the load-once set so a failed parent
+    // import does not leave nested modules marked loaded while their
+    // declarations were rolled back.
+    // Rollback is binding-table only (not deep object/array mutations or I/O).
     const snapshot = root.captureLocals();
+    const loadedSnapshot = new Set(loaded);
     loading.add(absolute);
     try {
       const parser = new Parser();
@@ -150,6 +164,7 @@ export const injiza: NativeFnValue = defineNative({
         return result;
       } catch (error: unknown) {
         root.restoreLocals(snapshot);
+        restoreSet(loaded, loadedSnapshot);
         withImportContext(error, source, absolute);
       }
     } finally {

--- a/src/runtime/path-resolve.ts
+++ b/src/runtime/path-resolve.ts
@@ -1,0 +1,51 @@
+/*************************************************************************************************************
+ *                                              Path resolution                                              *
+ *  Resolve script-relative paths for KIN_INYANDIKO and injiza(). Nested imports push the current file so    *
+ *  relative paths resolve against the file being evaluated, not only the entry script.                      *
+ *************************************************************************************************************/
+
+import path from 'path';
+import Environment from './environment';
+import { StringVal } from './values';
+
+/** Absolute paths of files currently being evaluated (entry script + injiza stack). */
+const currentFileStack: string[] = [];
+
+/**
+ * Resolve a path relative to the file currently being evaluated.
+ * Falls back to the `filename` binding (entry script / REPL cwd) when the stack is empty.
+ * Absolute paths are returned as-is (normalized).
+ */
+export function resolveKinPath(env: Environment, relativeOrAbsolute: string): string {
+  if (path.isAbsolute(relativeOrAbsolute)) {
+    return path.normalize(relativeOrAbsolute);
+  }
+
+  const baseFile =
+    currentFileStack[currentFileStack.length - 1] ??
+    resolveEntryFilename(env);
+
+  return path.resolve(path.dirname(baseFile), relativeOrAbsolute);
+}
+
+/** Normalize the entry `filename` binding to an absolute path. */
+export function resolveEntryFilename(env: Environment): string {
+  const raw = (env.lookupVar('filename') as StringVal).value;
+  if (path.isAbsolute(raw)) {
+    return path.normalize(raw);
+  }
+  return path.resolve(process.cwd(), raw);
+}
+
+/**
+ * Run `fn` with `absolutePath` as the current file for relative path resolution.
+ * Used by `injiza` so nested imports and file I/O see the imported file's directory.
+ */
+export function withCurrentFile<T>(absolutePath: string, fn: () => T): T {
+  currentFileStack.push(path.normalize(absolutePath));
+  try {
+    return fn();
+  } finally {
+    currentFileStack.pop();
+  }
+}

--- a/src/runtime/path-resolve.ts
+++ b/src/runtime/path-resolve.ts
@@ -8,7 +8,11 @@ import path from 'path';
 import Environment from './environment';
 import { StringVal } from './values';
 
-/** Absolute paths of files currently being evaluated (entry script + injiza stack). */
+/**
+ * Absolute paths of files currently being evaluated (entry script + injiza stack).
+ * Process-global by design: Kin evaluation is single-threaded. Concurrent
+ * evaluate() calls in the same process can cross-resolve relative paths.
+ */
 const currentFileStack: string[] = [];
 
 /**

--- a/tests/examples.test.ts
+++ b/tests/examples.test.ts
@@ -1,10 +1,11 @@
-import { readdirSync, readFileSync } from 'fs';
+import { readdirSync, readFileSync, statSync } from 'fs';
 import path from 'path';
 import { afterEach, beforeEach, describe, expect, test, vi } from 'vitest';
 import * as log from '../src/lib/log';
 import Parser from '../src/parser/parser';
 import { Interpreter } from '../src/runtime/interpreter';
 import { createGlobalEnv } from '../src/runtime/globals';
+import { withCurrentFile } from '../src/runtime/path-resolve';
 
 const promptAnswers = vi.hoisted(() => ({
   queue: [] as Array<string | null>,
@@ -27,13 +28,30 @@ const EXAMPLE_INPUTS: Record<string, string[]> = {
   'switch.kin': ['a'],
 };
 
-function runExample(filename: string): void {
-  const filePath = path.join(EXAMPLES_DIR, filename);
+/** Collect .kin entry files: top-level plus known multi-file entrypoints. */
+function listExampleEntries(): string[] {
+  const top = readdirSync(EXAMPLES_DIR)
+    .filter((file) => file.endsWith('.kin'))
+    .sort();
+  const nested: string[] = [];
+  for (const name of readdirSync(EXAMPLES_DIR)) {
+    const full = path.join(EXAMPLES_DIR, name);
+    if (statSync(full).isDirectory() && name === 'imports') {
+      nested.push(path.join(name, 'main.kin'));
+    }
+  }
+  return [...top, ...nested];
+}
+
+function runExample(relativePath: string): void {
+  const filePath = path.join(EXAMPLES_DIR, relativePath);
   const source = readFileSync(filePath, 'utf-8');
   const parser = new Parser();
   const ast = parser.produceAST(source);
   const env = createGlobalEnv(filePath);
-  Interpreter.evaluate(ast, env);
+  withCurrentFile(path.resolve(filePath), () => {
+    Interpreter.evaluate(ast, env);
+  });
 }
 
 describe('Example programs (current language implementation)', () => {
@@ -46,9 +64,7 @@ describe('Example programs (current language implementation)', () => {
     vi.restoreAllMocks();
   });
 
-  const examples = readdirSync(EXAMPLES_DIR)
-    .filter((file) => file.endsWith('.kin'))
-    .sort();
+  const examples = listExampleEntries();
 
   test('discovers at least the shipped example programs', () => {
     expect(examples.length).toBeGreaterThan(0);
@@ -61,12 +77,14 @@ describe('Example programs (current language implementation)', () => {
         'loops.kin',
         'objects.kin',
         'switch.kin',
+        'imports/main.kin',
       ]),
     );
   });
 
   test.each(examples)('runs %s without throwing', (filename) => {
-    promptAnswers.queue = [...(EXAMPLE_INPUTS[filename] ?? [])];
+    const base = path.basename(filename);
+    promptAnswers.queue = [...(EXAMPLE_INPUTS[base] ?? [])];
     expect(() => runExample(filename)).not.toThrow();
   });
 });

--- a/tests/globals.test.ts
+++ b/tests/globals.test.ts
@@ -718,6 +718,7 @@ describe('createGlobalEnv', () => {
         'tangaza_amakuru',
         'sisitemu',
         'injiza_amakuru',
+        'injiza',
         'hagarara',
         'KIN_IMIBARE',
         'KIN_AMAGAMBO',
@@ -792,6 +793,7 @@ describe('createGlobalEnv', () => {
         'tangaza_amakuru',
         'sisitemu',
         'injiza_amakuru',
+        'injiza',
         'hagarara',
         'ubwoko',
       ]) {

--- a/tests/imports.test.ts
+++ b/tests/imports.test.ts
@@ -290,22 +290,8 @@ reka a = 1
 reka b = 2
 `,
     );
-    writeFileSync(
-      path.join(tmpDir, 'main.kin'),
-      `
-porogaramu_ntoya try_bad() {
-  injiza("partial.kin")
-}
-# first import fails mid-file
-reka failed = sibyo
-niba (sibyo) {
-}
-# call via a path that surfaces the error then continues is hard in Kin;
-# assert rollback via direct evaluate in this test helper below.
-`,
-    );
 
-    // Direct: first injiza fails, second with fixed file works, `a` not polluted from partial.
+    // First injiza fails, second with fixed file works; partial `a` not left behind.
     const entry = path.join(tmpDir, 'driver.kin');
     writeFileSync(entry, `reka ok = 0`);
     const env = createGlobalEnv(entry);

--- a/tests/imports.test.ts
+++ b/tests/imports.test.ts
@@ -1,0 +1,209 @@
+import {
+  mkdirSync,
+  mkdtempSync,
+  readFileSync,
+  rmSync,
+  writeFileSync,
+} from 'fs';
+import os from 'os';
+import path from 'path';
+import { afterEach, beforeEach, describe, expect, test, vi } from 'vitest';
+import * as log from '../src/lib/log';
+import Parser from '../src/parser/parser';
+import { Interpreter } from '../src/runtime/interpreter';
+import { createGlobalEnv } from '../src/runtime/globals';
+import { withCurrentFile } from '../src/runtime/path-resolve';
+import { KinError } from '../src/lib/errors';
+import Environment from '../src/runtime/environment';
+import { asNumber, asString, evaluate } from './helpers';
+
+function runFile(entryPath: string): Environment {
+  const source = readFileSync(entryPath, 'utf-8');
+  const parser = new Parser();
+  const ast = parser.produceAST(source);
+  const env = createGlobalEnv(entryPath);
+  withCurrentFile(path.resolve(entryPath), () => {
+    Interpreter.evaluate(ast, env);
+  });
+  return env;
+}
+
+describe('injiza (multi-file import)', () => {
+  let tmpDir: string;
+
+  beforeEach(() => {
+    tmpDir = mkdtempSync(path.join(os.tmpdir(), 'kin-import-'));
+    vi.spyOn(log, 'LogMessage').mockImplementation(() => undefined);
+  });
+
+  afterEach(() => {
+    rmSync(tmpDir, { recursive: true, force: true });
+    vi.restoreAllMocks();
+  });
+
+  test('loads declarations and functions into the caller environment', () => {
+    writeFileSync(
+      path.join(tmpDir, 'utils.kin'),
+      `
+porogaramu_ntoya ongera(a, b) {
+  tanga a + b
+}
+reka PI = 3
+`,
+    );
+    writeFileSync(
+      path.join(tmpDir, 'main.kin'),
+      `
+injiza("utils.kin")
+reka sum = ongera(2, 3)
+reka out = sum + PI
+`,
+    );
+
+    const env = runFile(path.join(tmpDir, 'main.kin'));
+    expect(asNumber(env.lookupVar('sum'))).toBe(5);
+    expect(asNumber(env.lookupVar('out'))).toBe(8);
+    expect(asNumber(env.lookupVar('PI'))).toBe(3);
+  });
+
+  test('resolves paths relative to the importing file', () => {
+    const libDir = path.join(tmpDir, 'lib');
+    mkdirSync(libDir);
+    writeFileSync(
+      path.join(libDir, 'helper.kin'),
+      `reka from_helper = 42`,
+    );
+    writeFileSync(
+      path.join(tmpDir, 'main.kin'),
+      `
+injiza("lib/helper.kin")
+reka x = from_helper
+`,
+    );
+
+    const env = runFile(path.join(tmpDir, 'main.kin'));
+    expect(asNumber(env.lookupVar('x'))).toBe(42);
+  });
+
+  test('nested imports resolve relative to the nested file', () => {
+    const libDir = path.join(tmpDir, 'lib');
+    mkdirSync(libDir);
+    writeFileSync(
+      path.join(libDir, 'deep.kin'),
+      `reka deep_val = 7`,
+    );
+    writeFileSync(
+      path.join(libDir, 'mid.kin'),
+      `
+injiza("deep.kin")
+reka mid_val = deep_val + 1
+`,
+    );
+    writeFileSync(
+      path.join(tmpDir, 'main.kin'),
+      `
+injiza("lib/mid.kin")
+reka total = mid_val + deep_val
+`,
+    );
+
+    const env = runFile(path.join(tmpDir, 'main.kin'));
+    expect(asNumber(env.lookupVar('deep_val'))).toBe(7);
+    expect(asNumber(env.lookupVar('mid_val'))).toBe(8);
+    expect(asNumber(env.lookupVar('total'))).toBe(15);
+  });
+
+  test('load-once: second injiza of the same file is a no-op', () => {
+    writeFileSync(
+      path.join(tmpDir, 'once.kin'),
+      `reka counter = 1`,
+    );
+    writeFileSync(
+      path.join(tmpDir, 'main.kin'),
+      `
+injiza("once.kin")
+injiza("once.kin")
+reka c = counter
+`,
+    );
+
+    const env = runFile(path.join(tmpDir, 'main.kin'));
+    expect(asNumber(env.lookupVar('c'))).toBe(1);
+  });
+
+  test('throws K032 when the file does not exist', () => {
+    writeFileSync(
+      path.join(tmpDir, 'main.kin'),
+      `injiza("missing.kin")`,
+    );
+
+    try {
+      runFile(path.join(tmpDir, 'main.kin'));
+      throw new Error('expected K032');
+    } catch (e) {
+      expect(e).toBeInstanceOf(KinError);
+      expect((e as KinError).code).toBe('K032');
+      expect((e as KinError).message).toMatch(/missing\.kin/);
+    }
+  });
+
+  test('throws K033 on circular imports', () => {
+    writeFileSync(
+      path.join(tmpDir, 'a.kin'),
+      `injiza("b.kin")`,
+    );
+    writeFileSync(
+      path.join(tmpDir, 'b.kin'),
+      `injiza("a.kin")`,
+    );
+    writeFileSync(
+      path.join(tmpDir, 'main.kin'),
+      `injiza("a.kin")`,
+    );
+
+    try {
+      runFile(path.join(tmpDir, 'main.kin'));
+      throw new Error('expected K033');
+    } catch (e) {
+      expect(e).toBeInstanceOf(KinError);
+      expect((e as KinError).code).toBe('K033');
+    }
+  });
+
+  test('arity and type checks for injiza', () => {
+    expect(() => evaluate('injiza()')).toThrow(/injiza expects at least one argument/);
+    expect(() => evaluate('injiza(1)')).toThrow(/expects argument 1 to be string/);
+  });
+
+  test('imported top-level side effects run once', () => {
+    writeFileSync(
+      path.join(tmpDir, 'side.kin'),
+      `tangaza_amakuru("loaded")`,
+    );
+    writeFileSync(
+      path.join(tmpDir, 'main.kin'),
+      `
+injiza("side.kin")
+injiza("side.kin")
+`,
+    );
+
+    runFile(path.join(tmpDir, 'main.kin'));
+    expect(log.LogMessage).toHaveBeenCalledTimes(1);
+    expect(log.LogMessage).toHaveBeenCalledWith('loaded');
+  });
+
+  test('absolute paths work', () => {
+    const absUtils = path.join(tmpDir, 'abs-utils.kin');
+    writeFileSync(absUtils, `reka abs_ok = "yego"`);
+    writeFileSync(
+      path.join(tmpDir, 'main.kin'),
+      `injiza("${absUtils.replace(/\\/g, '/')}")
+reka v = abs_ok
+`,
+    );
+
+    const env = runFile(path.join(tmpDir, 'main.kin'));
+    expect(asString(env.lookupVar('v'))).toBe('yego');
+  });
+});

--- a/tests/imports.test.ts
+++ b/tests/imports.test.ts
@@ -397,13 +397,6 @@ reka c = content
 
   test('diamond import loads shared dependency once', () => {
     writeFileSync(
-      path.join(tmpDir, 'core.kin'),
-      `reka hits = 0
-hits = hits + 1
-`,
-    );
-    // hits reassignment - wait hits is declared then assigned. For load-once side effect:
-    writeFileSync(
       path.join(tmpDir, 'core2.kin'),
       `tangaza_amakuru("core")`,
     );
@@ -419,5 +412,110 @@ injiza("right.kin")
 
     runFile(path.join(tmpDir, 'main.kin'));
     expect(log.LogMessage).toHaveBeenCalledTimes(1);
+  });
+
+  test('multi-hop parse errors attribute to the leaf file', () => {
+    writeFileSync(path.join(tmpDir, 'bad.kin'), `reka =`);
+    writeFileSync(path.join(tmpDir, 'mid.kin'), `injiza("bad.kin")`);
+    writeFileSync(path.join(tmpDir, 'main.kin'), `injiza("mid.kin")`);
+
+    const err = expectRunError(path.join(tmpDir, 'main.kin'), 'K002');
+    expect(err.filename).toBe(path.resolve(tmpDir, 'bad.kin'));
+    expect(err.source).toContain('reka =');
+    const rendered = renderKinError(err, { color: false });
+    expect(rendered).toMatch(/bad\.kin/);
+    expect(rendered).not.toMatch(/mid\.kin:1/);
+  });
+
+  test('multi-hop runtime errors attribute to the leaf file', () => {
+    writeFileSync(path.join(tmpDir, 'leaf.kin'), `reka x = missing`);
+    writeFileSync(path.join(tmpDir, 'mid.kin'), `injiza("leaf.kin")`);
+    writeFileSync(path.join(tmpDir, 'a.kin'), `injiza("mid.kin")`);
+    writeFileSync(path.join(tmpDir, 'main.kin'), `injiza("a.kin")`);
+
+    const err = expectRunError(path.join(tmpDir, 'main.kin'), 'K005');
+    expect(err.filename).toBe(path.resolve(tmpDir, 'leaf.kin'));
+    expect(err.source).toContain('missing');
+  });
+
+  test('nested success then parent failure rolls back loaded set so child reloads', () => {
+    writeFileSync(path.join(tmpDir, 'inner.kin'), `reka INNER = 1`);
+    writeFileSync(
+      path.join(tmpDir, 'outer.kin'),
+      `
+injiza("inner.kin")
+reka boom = missing
+`,
+    );
+    writeFileSync(
+      path.join(tmpDir, 'outer_fixed.kin'),
+      `
+injiza("inner.kin")
+reka OUTER = INNER + 1
+`,
+    );
+
+    const entry = path.join(tmpDir, 'driver.kin');
+    writeFileSync(entry, `reka ok = 0`);
+    const env = createGlobalEnv(entry);
+    withCurrentFile(path.resolve(entry), () => {
+      try {
+        Interpreter.evaluate(
+          new Parser().produceAST(`injiza("outer.kin")`),
+          env,
+        );
+        throw new Error('expected outer failure');
+      } catch (e) {
+        expect(e).toBeInstanceOf(KinError);
+        expect((e as KinError).code).toBe('K005');
+      }
+      // Nested bindings must not remain.
+      expect(() => env.lookupVar('INNER')).toThrow();
+      // Child must not be stuck as "loaded"; re-import rebinds.
+      Interpreter.evaluate(
+        new Parser().produceAST(`injiza("inner.kin")`),
+        env,
+      );
+      expect(asNumber(env.lookupVar('INNER'))).toBe(1);
+      // Fixed parent re-import still works (inner already loaded once; outer adds OUTER).
+      Interpreter.evaluate(
+        new Parser().produceAST(`injiza("outer_fixed.kin")`),
+        env,
+      );
+      expect(asNumber(env.lookupVar('OUTER'))).toBe(2);
+    });
+  });
+
+  test('rollback is binding-table only (in-place object mutation survives)', () => {
+    writeFileSync(
+      path.join(tmpDir, 'mut.kin'),
+      `
+obj.a = 99
+reka boom = missing
+`,
+    );
+    const entry = path.join(tmpDir, 'driver.kin');
+    writeFileSync(entry, `reka obj = { a: 1 }`);
+    const env = createGlobalEnv(entry);
+    withCurrentFile(path.resolve(entry), () => {
+      Interpreter.evaluate(
+        new Parser().produceAST(`reka obj = { a: 1 }`),
+        env,
+      );
+      try {
+        Interpreter.evaluate(
+          new Parser().produceAST(`injiza("mut.kin")`),
+          env,
+        );
+        throw new Error('expected failure');
+      } catch (e) {
+        expect(e).toBeInstanceOf(KinError);
+      }
+      const obj = env.lookupVar('obj');
+      expect(obj.type).toBe('object');
+      const a = (obj as { properties: Map<string, { value: number }> })
+        .properties.get('a');
+      expect(a?.value).toBe(99);
+    });
   });
 });

--- a/tests/imports.test.ts
+++ b/tests/imports.test.ts
@@ -14,6 +14,7 @@ import { Interpreter } from '../src/runtime/interpreter';
 import { createGlobalEnv } from '../src/runtime/globals';
 import { withCurrentFile } from '../src/runtime/path-resolve';
 import { KinError } from '../src/lib/errors';
+import { renderKinError } from '../src/lib/render-error';
 import Environment from '../src/runtime/environment';
 import { asNumber, asString, evaluate } from './helpers';
 
@@ -26,6 +27,18 @@ function runFile(entryPath: string): Environment {
     Interpreter.evaluate(ast, env);
   });
   return env;
+}
+
+function expectRunError(entryPath: string, code: string): KinError {
+  try {
+    runFile(entryPath);
+  } catch (e) {
+    expect(e).toBeInstanceOf(KinError);
+    const err = e as KinError;
+    expect(err.code).toBe(code);
+    return err;
+  }
+  throw new Error(`expected KinError ${code}`);
 }
 
 describe('injiza (multi-file import)', () => {
@@ -41,7 +54,7 @@ describe('injiza (multi-file import)', () => {
     vi.restoreAllMocks();
   });
 
-  test('loads declarations and functions into the caller environment', () => {
+  test('loads declarations and functions into the program environment', () => {
     writeFileSync(
       path.join(tmpDir, 'utils.kin'),
       `
@@ -69,10 +82,7 @@ reka out = sum + PI
   test('resolves paths relative to the importing file', () => {
     const libDir = path.join(tmpDir, 'lib');
     mkdirSync(libDir);
-    writeFileSync(
-      path.join(libDir, 'helper.kin'),
-      `reka from_helper = 42`,
-    );
+    writeFileSync(path.join(libDir, 'helper.kin'), `reka from_helper = 42`);
     writeFileSync(
       path.join(tmpDir, 'main.kin'),
       `
@@ -88,10 +98,7 @@ reka x = from_helper
   test('nested imports resolve relative to the nested file', () => {
     const libDir = path.join(tmpDir, 'lib');
     mkdirSync(libDir);
-    writeFileSync(
-      path.join(libDir, 'deep.kin'),
-      `reka deep_val = 7`,
-    );
+    writeFileSync(path.join(libDir, 'deep.kin'), `reka deep_val = 7`);
     writeFileSync(
       path.join(libDir, 'mid.kin'),
       `
@@ -114,10 +121,7 @@ reka total = mid_val + deep_val
   });
 
   test('load-once: second injiza of the same file is a no-op', () => {
-    writeFileSync(
-      path.join(tmpDir, 'once.kin'),
-      `reka counter = 1`,
-    );
+    writeFileSync(path.join(tmpDir, 'once.kin'), `reka counter = 1`);
     writeFileSync(
       path.join(tmpDir, 'main.kin'),
       `
@@ -132,47 +136,29 @@ reka c = counter
   });
 
   test('throws K032 when the file does not exist', () => {
-    writeFileSync(
-      path.join(tmpDir, 'main.kin'),
-      `injiza("missing.kin")`,
-    );
-
-    try {
-      runFile(path.join(tmpDir, 'main.kin'));
-      throw new Error('expected K032');
-    } catch (e) {
-      expect(e).toBeInstanceOf(KinError);
-      expect((e as KinError).code).toBe('K032');
-      expect((e as KinError).message).toMatch(/missing\.kin/);
-    }
+    writeFileSync(path.join(tmpDir, 'main.kin'), `injiza("missing.kin")`);
+    const err = expectRunError(path.join(tmpDir, 'main.kin'), 'K032');
+    expect(err.ERRNAME).toBe('RuntimeError');
+    expect(err.ERRCODE).toBe('E_RUNTIME');
+    expect(err.message).toMatch(/missing\.kin/);
   });
 
   test('throws K033 on circular imports', () => {
-    writeFileSync(
-      path.join(tmpDir, 'a.kin'),
-      `injiza("b.kin")`,
-    );
-    writeFileSync(
-      path.join(tmpDir, 'b.kin'),
-      `injiza("a.kin")`,
-    );
-    writeFileSync(
-      path.join(tmpDir, 'main.kin'),
-      `injiza("a.kin")`,
-    );
-
-    try {
-      runFile(path.join(tmpDir, 'main.kin'));
-      throw new Error('expected K033');
-    } catch (e) {
-      expect(e).toBeInstanceOf(KinError);
-      expect((e as KinError).code).toBe('K033');
-    }
+    writeFileSync(path.join(tmpDir, 'a.kin'), `injiza("b.kin")`);
+    writeFileSync(path.join(tmpDir, 'b.kin'), `injiza("a.kin")`);
+    writeFileSync(path.join(tmpDir, 'main.kin'), `injiza("a.kin")`);
+    const err = expectRunError(path.join(tmpDir, 'main.kin'), 'K033');
+    expect(err.ERRNAME).toBe('RuntimeError');
+    expect(err.ERRCODE).toBe('E_RUNTIME');
   });
 
   test('arity and type checks for injiza', () => {
-    expect(() => evaluate('injiza()')).toThrow(/injiza expects at least one argument/);
-    expect(() => evaluate('injiza(1)')).toThrow(/expects argument 1 to be string/);
+    expect(() => evaluate('injiza()')).toThrow(
+      /injiza expects at least one argument/,
+    );
+    expect(() => evaluate('injiza(1)')).toThrow(
+      /expects argument 1 to be string/,
+    );
   });
 
   test('imported top-level side effects run once', () => {
@@ -205,5 +191,233 @@ reka v = abs_ok
 
     const env = runFile(path.join(tmpDir, 'main.kin'));
     expect(asString(env.lookupVar('v'))).toBe('yego');
+  });
+
+  test('injiza from inside a function installs program-level bindings', () => {
+    writeFileSync(path.join(tmpDir, 'lib.kin'), `reka shared = 99`);
+    writeFileSync(
+      path.join(tmpDir, 'main.kin'),
+      `
+porogaramu_ntoya load() {
+  injiza("lib.kin")
+}
+load()
+reka x = shared
+`,
+    );
+
+    const env = runFile(path.join(tmpDir, 'main.kin'));
+    expect(asNumber(env.lookupVar('x'))).toBe(99);
+    expect(asNumber(env.lookupVar('shared'))).toBe(99);
+  });
+
+  test('injiza from niba / loop installs program-level bindings', () => {
+    writeFileSync(path.join(tmpDir, 'cond.kin'), `reka from_cond = 1`);
+    writeFileSync(path.join(tmpDir, 'loop.kin'), `reka from_loop = 2`);
+    writeFileSync(
+      path.join(tmpDir, 'main.kin'),
+      `
+niba (nibyo) {
+  injiza("cond.kin")
+}
+reka i = 0
+subiramo_niba (i < 1) {
+  injiza("loop.kin")
+  i = i + 1
+}
+reka total = from_cond + from_loop
+`,
+    );
+
+    const env = runFile(path.join(tmpDir, 'main.kin'));
+    expect(asNumber(env.lookupVar('total'))).toBe(3);
+  });
+
+  test('load-once from nested scope still exposes bindings at top level', () => {
+    writeFileSync(path.join(tmpDir, 'once.kin'), `reka g = 7`);
+    writeFileSync(
+      path.join(tmpDir, 'main.kin'),
+      `
+porogaramu_ntoya load() {
+  injiza("once.kin")
+}
+load()
+injiza("once.kin")
+reka v = g
+`,
+    );
+
+    const env = runFile(path.join(tmpDir, 'main.kin'));
+    expect(asNumber(env.lookupVar('v'))).toBe(7);
+  });
+
+  test('parse errors in imported files attribute to the dependency', () => {
+    writeFileSync(path.join(tmpDir, 'bad.kin'), `reka =`);
+    writeFileSync(path.join(tmpDir, 'main.kin'), `injiza("bad.kin")`);
+
+    const err = expectRunError(path.join(tmpDir, 'main.kin'), 'K002');
+    expect(err.filename).toBe(path.resolve(tmpDir, 'bad.kin'));
+    expect(err.source).toContain('reka =');
+    const rendered = renderKinError(err, { color: false });
+    expect(rendered).toMatch(/bad\.kin/);
+    expect(rendered).toMatch(/reka =/);
+  });
+
+  test('runtime errors in imported files attribute to the dependency', () => {
+    writeFileSync(path.join(tmpDir, 'rt.kin'), `tangaza_amakuru(missing_name)`);
+    writeFileSync(path.join(tmpDir, 'main.kin'), `injiza("rt.kin")`);
+
+    const err = expectRunError(path.join(tmpDir, 'main.kin'), 'K005');
+    expect(err.filename).toBe(path.resolve(tmpDir, 'rt.kin'));
+    expect(err.source).toContain('missing_name');
+    const rendered = renderKinError(err, { color: false });
+    expect(rendered).toMatch(/rt\.kin/);
+    expect(rendered).toMatch(/missing_name/);
+  });
+
+  test('failed import rolls back partial bindings so re-import can succeed', () => {
+    writeFileSync(
+      path.join(tmpDir, 'partial.kin'),
+      `
+reka a = 1
+reka b = missing
+`,
+    );
+    writeFileSync(
+      path.join(tmpDir, 'fixed.kin'),
+      `
+reka a = 1
+reka b = 2
+`,
+    );
+    writeFileSync(
+      path.join(tmpDir, 'main.kin'),
+      `
+porogaramu_ntoya try_bad() {
+  injiza("partial.kin")
+}
+# first import fails mid-file
+reka failed = sibyo
+niba (sibyo) {
+}
+# call via a path that surfaces the error then continues is hard in Kin;
+# assert rollback via direct evaluate in this test helper below.
+`,
+    );
+
+    // Direct: first injiza fails, second with fixed file works, `a` not polluted from partial.
+    const entry = path.join(tmpDir, 'driver.kin');
+    writeFileSync(entry, `reka ok = 0`);
+    const env = createGlobalEnv(entry);
+    withCurrentFile(path.resolve(entry), () => {
+      try {
+        Interpreter.evaluate(
+          new Parser().produceAST(`injiza("partial.kin")`),
+          env,
+        );
+        throw new Error('expected failure');
+      } catch (e) {
+        expect(e).toBeInstanceOf(KinError);
+        expect((e as KinError).code).toBe('K005');
+      }
+      // Partial `a` must not remain.
+      expect(() => env.lookupVar('a')).toThrow();
+      Interpreter.evaluate(
+        new Parser().produceAST(`injiza("fixed.kin")`),
+        env,
+      );
+      expect(asNumber(env.lookupVar('a'))).toBe(1);
+      expect(asNumber(env.lookupVar('b'))).toBe(2);
+    });
+  });
+
+  test('self-injiza of entry without .kin extension is a no-op', () => {
+    const entry = path.join(tmpDir, 'main.txt');
+    writeFileSync(
+      entry,
+      `
+reka x = 1
+injiza("main.txt")
+reka y = x + 1
+`,
+    );
+
+    const env = runFile(entry);
+    expect(asNumber(env.lookupVar('x'))).toBe(1);
+    expect(asNumber(env.lookupVar('y'))).toBe(2);
+  });
+
+  test('self-injiza of .kin entry is a no-op', () => {
+    writeFileSync(
+      path.join(tmpDir, 'main.kin'),
+      `
+reka x = 5
+injiza("main.kin")
+reka y = x
+`,
+    );
+
+    const env = runFile(path.join(tmpDir, 'main.kin'));
+    expect(asNumber(env.lookupVar('y'))).toBe(5);
+  });
+
+  test('redeclaration across files raises K007', () => {
+    writeFileSync(path.join(tmpDir, 'a.kin'), `reka shared = 1`);
+    writeFileSync(path.join(tmpDir, 'b.kin'), `reka shared = 2`);
+    writeFileSync(
+      path.join(tmpDir, 'main.kin'),
+      `
+injiza("a.kin")
+injiza("b.kin")
+`,
+    );
+
+    expectRunError(path.join(tmpDir, 'main.kin'), 'K007');
+  });
+
+  test('KIN_INYANDIKO paths inside an imported file are relative to that file', () => {
+    const libDir = path.join(tmpDir, 'lib');
+    mkdirSync(libDir);
+    writeFileSync(path.join(libDir, 'data.txt'), 'from-lib');
+    writeFileSync(
+      path.join(libDir, 'reader.kin'),
+      `reka content = KIN_INYANDIKO.soma("data.txt")`,
+    );
+    writeFileSync(
+      path.join(tmpDir, 'main.kin'),
+      `
+injiza("lib/reader.kin")
+reka c = content
+`,
+    );
+
+    const env = runFile(path.join(tmpDir, 'main.kin'));
+    expect(asString(env.lookupVar('c'))).toBe('from-lib');
+  });
+
+  test('diamond import loads shared dependency once', () => {
+    writeFileSync(
+      path.join(tmpDir, 'core.kin'),
+      `reka hits = 0
+hits = hits + 1
+`,
+    );
+    // hits reassignment - wait hits is declared then assigned. For load-once side effect:
+    writeFileSync(
+      path.join(tmpDir, 'core2.kin'),
+      `tangaza_amakuru("core")`,
+    );
+    writeFileSync(path.join(tmpDir, 'left.kin'), `injiza("core2.kin")`);
+    writeFileSync(path.join(tmpDir, 'right.kin'), `injiza("core2.kin")`);
+    writeFileSync(
+      path.join(tmpDir, 'main.kin'),
+      `
+injiza("left.kin")
+injiza("right.kin")
+`,
+    );
+
+    runFile(path.join(tmpDir, 'main.kin'));
+    expect(log.LogMessage).toHaveBeenCalledTimes(1);
   });
 });


### PR DESCRIPTION
## Summary

Implements multi-file support for Kin as requested in #169.

`injiza("path.kin")` loads and runs another Kin source file in the **program (global) environment**, so top-level variables and functions declared in the imported file become available program-wide (including when `injiza` is called from a function, `niba`, or loop).

### Behavior
- **Path resolution**: relative to the file containing `injiza` (absolute paths work too); nested imports resolve against the nested file
- **Load once**: each absolute path is evaluated once per run; re-import is a no-op
- **Shared bindings**: top-level declarations land in the root/global env
- **Failed import**: snapshots root bindings **and** the load-once set; rolls both back so nested modules can reload
- **Rollback scope**: binding-table only (not deep object/array mutations or host I/O)
- **Error attribution**: parse/runtime errors keep the **leaf** dependency path through multi-hop imports
- **Errors**: missing file → `K032`; circular import → `K033`; name clash → `K007`
- **`kin check`**: single-file only (does not follow `injiza`); documented

### Review history
- **Cycle 1**: root-env eval, single-hop attribution, binding rollback, entry seed, tests/docs
- **Cycle 2**: preserve nested attribution; restore loaded-set with bindings; multi-hop tests; document shallow rollback

Closes #169

## Test plan

- [x] `npm test` — 247 tests passed
- [x] `npm run build` — tsc clean
- [x] Nested-scope import + top-level use
- [x] Multi-hop parse/runtime frames on leaf path
- [x] Nested success + parent fail + child reload
- [x] Self-import entry (`.kin` and non-`.kin`)
- [x] examples/imports smoke test

## Monorepo follow-ups

| Package | PR |
|---------|-----|
| **vscode-intellisense** | https://github.com/kin-lang/vscode-intellisense/pull/10 |
| **wiki** | https://github.com/kin-lang/wiki/pull/23 |
| **editor** | No change required |