### PR TITLE
feat: variable type annotations (required / optional)

### DIFF
--- a/bin/kin.ts
+++ b/bin/kin.ts
@@ -6,9 +6,12 @@ import { readFile } from 'fs/promises';
 import {
   Interpreter,
   Parser,
+  applyTypeSafetyToEnv,
   createGlobalEnv,
   isKinError,
+  normalizeTypeSafetyMode,
   renderThrown,
+  runSource,
 } from '../src/index';
 import * as readline from 'readline/promises';
 
@@ -51,9 +54,25 @@ program
 program
   .command('repl')
   .description("Enter Kin's Repl")
-  .action(async () => {
+  .option(
+    '--types <mode>',
+    'Type safety: on (default), off, or strict. Overrides # kin-types: and KIN_TYPES.',
+  )
+  .action(async (opts: { types?: string }) => {
+    if (opts.types && !normalizeTypeSafetyMode(opts.types)) {
+      console.error(
+        `Kin Error: Invalid --types mode '${opts.types}'. Use on, off, or strict.`,
+      );
+      process.exit(1);
+    }
     const parser = new Parser();
-    const env = createGlobalEnv(process.cwd());
+    if (opts.types) parser.setTypeSafetyOverride(opts.types);
+    // Initial mode from CLI / KIN_TYPES (no source yet).
+    const initialMode =
+      normalizeTypeSafetyMode(opts.types) ??
+      normalizeTypeSafetyMode(process.env.KIN_TYPES) ??
+      'on';
+    const env = createGlobalEnv(process.cwd(), { typeSafety: initialMode });
 
     console.log(`Repl ${pkg.version} (Kin)`);
 
@@ -65,7 +84,14 @@ program
       }
 
       try {
-        const { program: ast, diagnostics } = parser.parse(input);
+        // Per-line override still wins when set; otherwise re-resolve from
+        // this line's `# kin-types:` directive (and env), then apply to env
+        // so runtime checks stay aligned with the parser.
+        if (!opts.types) {
+          parser.setTypeSafetyOverride(undefined);
+        }
+        const { program: ast, diagnostics, typeSafety } = parser.parse(input);
+        applyTypeSafetyToEnv(env, typeSafety);
         if (diagnostics.length > 0) {
           for (const d of diagnostics) {
             printError(d.error, input, 'repl');
@@ -82,20 +108,31 @@ program
 program
   .command('run <file_location>')
   .description('Runs a given file.')
-  .action(async (file_location) => {
+  .option(
+    '--types <mode>',
+    'Type safety: on (default), off, or strict. Overrides # kin-types: and KIN_TYPES.',
+  )
+  .action(async (file_location, opts: { types?: string }) => {
     let source_codes = '';
     try {
+      if (opts.types && !normalizeTypeSafetyMode(opts.types)) {
+        console.error(
+          `Kin Error: Invalid --types mode '${opts.types}'. Use on, off, or strict.`,
+        );
+        process.exit(1);
+      }
       source_codes = await readFile(file_location, 'utf-8');
-      const parser = new Parser();
-      const { program: ast, diagnostics } = parser.parse(source_codes);
+      const { diagnostics } = runSource(source_codes, {
+        filename: file_location,
+        typeSafety: opts.types,
+        throwOnDiagnostic: false,
+      });
       if (diagnostics.length > 0) {
         for (const d of diagnostics) {
           printError(d.error, source_codes, file_location);
         }
         process.exit(1);
       }
-      const env = createGlobalEnv(file_location);
-      Interpreter.evaluate(ast, env);
       process.exit(0);
     } catch (error: unknown) {
       if (
@@ -115,11 +152,22 @@ program
 program
   .command('check <file_location>')
   .description('Parse a file and report diagnostics without executing.')
-  .action(async (file_location) => {
+  .option(
+    '--types <mode>',
+    'Type safety: on (default), off, or strict. Overrides # kin-types: and KIN_TYPES.',
+  )
+  .action(async (file_location, opts: { types?: string }) => {
     let source_codes = '';
     try {
+      if (opts.types && !normalizeTypeSafetyMode(opts.types)) {
+        console.error(
+          `Kin Error: Invalid --types mode '${opts.types}'. Use on, off, or strict.`,
+        );
+        process.exit(1);
+      }
       source_codes = await readFile(file_location, 'utf-8');
       const parser = new Parser();
+      parser.setTypeSafetyOverride(opts.types);
       const { diagnostics } = parser.parse(source_codes);
       if (diagnostics.length === 0) {
         console.log(`No issues found in ${file_location}`);

--- a/docs/errors.md
+++ b/docs/errors.md
@@ -49,7 +49,7 @@ Host programs can branch on `instanceof`, `ERRNAME`, or `ERRCODE`.
 | K029 | RuntimeError | Unhandled type in equality | internal | Report to Kin developers. |
 | K030 | SyntaxError | Expected function name following porogaramu_ntoya | `porogaramu_ntoya (){}` | Name the function. |
 | K031 | SyntaxError | Variable name expected following reka or ntahinduka | `reka = 1` | Write `reka name = ...`. |
-| K032 | SyntaxError | Unknown type name '{name}' | `reka x: foo = 1` | Use a built-in type: number, string, boolean, object, urutonde, fn. |
+| K032 | SyntaxError | Unknown type name '{name}' | `reka x: foo = 1` | Use a built-in type: number, string, boolean, object, urutonde, fn, native-fn. |
 | K033 | TypeError | Variable '{name}' expects type {expected}, got {got} | `reka x: number = "a"` | Assign a value of the annotated type. |
 | K034 | TypeError | Variable '{name}' has required type {expected} and cannot be ubusa | `reka x: number;` | Provide a non-null value, or use an optional type (`number?`). |
 | K035 | SyntaxError | Strict type safety requires a type annotation on '{name}' | `reka x = 1` under `# kin-types: strict` | Write `reka x: type = ...` or leave strict mode. |

--- a/docs/errors.md
+++ b/docs/errors.md
@@ -49,5 +49,9 @@ Host programs can branch on `instanceof`, `ERRNAME`, or `ERRCODE`.
 | K029 | RuntimeError | Unhandled type in equality | internal | Report to Kin developers. |
 | K030 | SyntaxError | Expected function name following porogaramu_ntoya | `porogaramu_ntoya (){}` | Name the function. |
 | K031 | SyntaxError | Variable name expected following reka or ntahinduka | `reka = 1` | Write `reka name = ...`. |
+| K032 | SyntaxError | Unknown type name '{name}' | `reka x: foo = 1` | Use a built-in type: number, string, boolean, object, urutonde, fn. |
+| K033 | TypeError | Variable '{name}' expects type {expected}, got {got} | `reka x: number = "a"` | Assign a value of the annotated type. |
+| K034 | TypeError | Variable '{name}' has required type {expected} and cannot be ubusa | `reka x: number;` | Provide a non-null value, or use an optional type (`number?`). |
+| K035 | SyntaxError | Strict type safety requires a type annotation on '{name}' | `reka x = 1` under `# kin-types: strict` | Write `reka x: type = ...` or leave strict mode. |
 
 Messages are loaded from `src/messages/rw.json` (default) and `src/messages/en.json` (`KIN_LANG=en`).

--- a/examples/types.kin
+++ b/examples/types.kin
@@ -1,0 +1,47 @@
+# Variable type annotations (issue #256)
+#
+# Type safety modes (file directive, env KIN_TYPES, or CLI --types):
+#   # kin-types: on      (default) check annotated bindings only
+#   # kin-types: off     ignore annotations
+#   # kin-types: strict  every reka/ntahinduka needs an annotation
+#
+# Syntax:
+#   reka name: type = value      # required type — rejects ubusa and wrong types
+#   reka name: type? = value     # optional type — allows ubusa
+#   reka name: type?;            # optional, starts as ubusa
+#   ntahinduka name: type = val  # typed constant
+#
+# Annotation names: number string boolean object urutonde fn (native-fn = fn)
+# ubwoko still reports raw tags (e.g. native-fn for builtins).
+# Unannotated bindings stay fully dynamic under the default `on` mode.
+
+# kin-types: on
+
+reka age: number = 25
+reka name: string = "Keza"
+reka ok: boolean = nibyo
+reka list: urutonde = [1, 2, 3]
+reka person: object = {izina: "Keza", imyaka: 25}
+reka maybe: number? = ubusa
+reka later: string?;
+
+porogaramu_ntoya ongera(a, b) {
+  tanga a + b
+}
+reka f: fn = ongera
+
+# Reassignment is checked too.
+age = 26
+maybe = 10
+maybe = ubusa
+later = "ready"
+
+tangaza_amakuru(age)
+tangaza_amakuru(name)
+tangaza_amakuru(ok)
+tangaza_amakuru(list[0])
+tangaza_amakuru(person.izina)
+tangaza_amakuru(maybe)
+tangaza_amakuru(later)
+tangaza_amakuru(f(2, 3))
+tangaza_amakuru(ubwoko(age))

--- a/grammar.bnf
+++ b/grammar.bnf
@@ -217,4 +217,5 @@ stringLiteral ::= '"' { anyCharacterExceptQuoteOrNewline } '"'
 ; &          tokenized (AMPERSAND), never parsed  (&& is AND and is used)
 ; |          lexer error unless it is part of ||
 ; '          not recognized; strings use " only
-; ?          used only as optional-type marker after a type name
+;
+; ? is used: optional-type marker after a type name (see typeAnnotation)

--- a/grammar.bnf
+++ b/grammar.bnf
@@ -37,8 +37,27 @@ statement ::= variableDeclaration
 ; Semicolon is required only when the initializer is omitted.
 ; Constants (ntahinduka) must have an initializer — the parser rejects
 ; "ntahinduka name ;".
-variableDeclaration ::= "reka" identifier (";" | "=" expression)
-                      | "ntahinduka" identifier "=" expression
+;
+; Optional type annotation after the name enables runtime type checks for
+; that binding (declare + reassign) when type safety is on or strict.
+; Unannotated bindings stay dynamic under `on`; under `strict` they error.
+; Required types reject ubusa; optional types (`type?`) accept ubusa.
+;
+; Annotation names: number string boolean object urutonde fn native-fn
+; Note: ubwoko still reports runtime tags "fn" vs "native-fn"; annotations
+; treat both as `fn` (and accept `native-fn` as a synonym of `fn`).
+variableDeclaration ::= "reka" identifier typeAnnotation? (";" | "=" expression)
+                      | "ntahinduka" identifier typeAnnotation? "=" expression
+
+typeAnnotation ::= ":" typeName "?"?
+typeName       ::= "number" | "string" | "boolean" | "object"
+                 | "urutonde" | "fn" | "native-fn"
+
+; Type-safety control (not a statement — a special comment or host flag):
+;   # kin-types: on      default; check annotated bindings only
+;   # kin-types: off     disable type checks (ignore annotations)
+;   # kin-types: strict  every reka/ntahinduka needs an annotation
+; Precedence: CLI --types > this directive > env KIN_TYPES > on
 
 functionDeclaration ::= "porogaramu_ntoya" identifier "(" parameterList? ")" block
 
@@ -198,3 +217,4 @@ stringLiteral ::= '"' { anyCharacterExceptQuoteOrNewline } '"'
 ; &          tokenized (AMPERSAND), never parsed  (&& is AND and is used)
 ; |          lexer error unless it is part of ||
 ; '          not recognized; strings use " only
+; ?          used only as optional-type marker after a type name

--- a/src/index.ts
+++ b/src/index.ts
@@ -38,6 +38,22 @@ import {
   CODE_CATEGORY,
 } from './lib/errors';
 import { renderKinError, renderThrown } from './lib/render-error';
+import {
+  BUILTIN_TYPE_NAMES,
+  assertValueMatchesType,
+  annotationTypeName,
+  formatTypeAnnotation,
+  isBuiltinTypeName,
+  normalizeAnnotationName,
+  normalizeTypeSafetyMode,
+  parseTypeSafetyDirective,
+  resolveTypeSafetyMode,
+  valueMatchesType,
+} from './runtime/types';
+import {
+  applyTypeSafetyToEnv,
+  runSource,
+} from './runtime/run';
 
 export {
   Parser,
@@ -69,6 +85,18 @@ export {
   CODE_CATEGORY,
   renderKinError,
   renderThrown,
+  BUILTIN_TYPE_NAMES,
+  assertValueMatchesType,
+  annotationTypeName,
+  formatTypeAnnotation,
+  isBuiltinTypeName,
+  normalizeAnnotationName,
+  normalizeTypeSafetyMode,
+  parseTypeSafetyDirective,
+  resolveTypeSafetyMode,
+  valueMatchesType,
+  runSource,
+  applyTypeSafetyToEnv,
 };
 
 export type {
@@ -88,3 +116,9 @@ export type {
   KinErrorCode,
   KinErrorOptions,
 } from './lib/errors';
+
+export type { TypeAnnotation } from './parser/ast';
+export type { TypeSafetyMode, BuiltinTypeName } from './runtime/types';
+export type { GlobalEnvOptions } from './runtime/globals';
+export type { ParseResult, Diagnostic } from './parser/parser';
+export type { RunSourceOptions, RunSourceResult } from './runtime/run';

--- a/src/lexer/lexer.ts
+++ b/src/lexer/lexer.ts
@@ -349,6 +349,9 @@ class Lexer {
       case ':':
         this.advance();
         return this.makeToken(TokenType.COLON, ':', start, line, column);
+      case '?':
+        this.advance();
+        return this.makeToken(TokenType.QUESTION, '?', start, line, column);
       case '>':
         this.advance();
         if (this.peek() == '=') {

--- a/src/lexer/tokens.ts
+++ b/src/lexer/tokens.ts
@@ -24,6 +24,8 @@ enum TokenType {
   SINGLE_QUOTATION,
   DOUBLE_QUOTATION,
   COLON,
+  /** Optional type marker: `number?` */
+  QUESTION,
   GREATER_THAN,
   LESS_THAN,
   COMMA,

--- a/src/lib/errors.ts
+++ b/src/lib/errors.ts
@@ -45,6 +45,8 @@ export const CODE_CATEGORY: Readonly<Record<string, KinErrorName>> = {
   K023: 'SyntaxError',
   K030: 'SyntaxError',
   K031: 'SyntaxError',
+  K032: 'SyntaxError',
+  K035: 'SyntaxError',
 
   // Reference — names / bindings
   K005: 'ReferenceError',
@@ -61,6 +63,8 @@ export const CODE_CATEGORY: Readonly<Record<string, KinErrorName>> = {
   K017: 'TypeError',
   K018: 'TypeError',
   K024: 'TypeError',
+  K033: 'TypeError',
+  K034: 'TypeError',
 
   // Runtime — control flow, exit, internals
   K013: 'RuntimeError',

--- a/src/messages/en.json
+++ b/src/messages/en.json
@@ -29,5 +29,9 @@
   "K028": "Unknown operator '{op}'",
   "K029": "Unhandled type in equality: {type}",
   "K030": "Expected function name following porogaramu_ntoya",
-  "K031": "Variable name expected following reka or ntahinduka"
+  "K031": "Variable name expected following reka or ntahinduka",
+  "K032": "Unknown type name '{name}'. Expected one of: {allowed}",
+  "K033": "Variable '{name}' expects type {expected}, got {got}",
+  "K034": "Variable '{name}' has required type {expected} and cannot be ubusa",
+  "K035": "Strict type safety requires a type annotation on '{name}' (e.g. reka {name}: number = ...)"
 }

--- a/src/messages/rw.json
+++ b/src/messages/rw.json
@@ -29,5 +29,9 @@
   "K028": "Ikimenyetso kitazwi '{op}'",
   "K029": "Ubwoko butazwi mu kugereranya: {type}",
   "K030": "Byari biteganyijwe izina rya porogaramu_ntoya",
-  "K031": "Byari biteganyijwe izina ry'ihinduragaciro nyuma ya reka cyangwa ntahinduka"
+  "K031": "Byari biteganyijwe izina ry'ihinduragaciro nyuma ya reka cyangwa ntahinduka",
+  "K032": "Izina ry'ubwoko '{name}' ntirizwi. Byari biteganyijwe kimwe muri: {allowed}",
+  "K033": "Ihinduragaciro '{name}' risaba ubwoko {expected}, habonetse {got}",
+  "K034": "Ihinduragaciro '{name}' rifite ubwoko ngombwa {expected} ntishobora kuba ubusa",
+  "K035": "Ubwoko bwa strict busaba ubwoko kuri '{name}' (urugero: reka {name}: number = ...)"
 }

--- a/src/parser/ast.ts
+++ b/src/parser/ast.ts
@@ -55,6 +55,18 @@ export interface Program extends Stmt {
 }
 
 /**
+ * Optional type annotation on a variable declaration.
+ * `optional: true` means the binding also accepts `ubusa` (null).
+ * Annotation names: number, string, boolean, object, urutonde, fn,
+ * native-fn (synonym of fn). Note: `ubwoko` still reports raw runtime
+ * tags (`fn` vs `native-fn`); annotations treat both as `fn`.
+ */
+export interface TypeAnnotation {
+  name: string;
+  optional: boolean;
+}
+
+/**
  * Defines a variable declaration
  */
 export interface VariableDeclaration extends Stmt {
@@ -62,6 +74,8 @@ export interface VariableDeclaration extends Stmt {
   constant: boolean;
   identifier: string;
   value?: Expr;
+  /** When set, runtime checks the value (and later assignments) against it. */
+  typeAnnotation?: TypeAnnotation;
 }
 
 /**
@@ -207,8 +221,17 @@ export function mkVarDecl(
   constant: boolean,
   value: Expr | undefined,
   span: Span,
+  typeAnnotation?: TypeAnnotation,
 ): VariableDeclaration {
-  return { kind: 'VariableDeclaration', identifier, constant, value, span };
+  const node: VariableDeclaration = {
+    kind: 'VariableDeclaration',
+    identifier,
+    constant,
+    value,
+    span,
+  };
+  if (typeAnnotation) node.typeAnnotation = typeAnnotation;
+  return node;
 }
 
 export function mkConditional(

--- a/src/parser/parser.ts
+++ b/src/parser/parser.ts
@@ -407,7 +407,8 @@ export default class Parser {
    * Optional type annotation after a binding name:
    *   : number
    *   : string?
-   * Names must be built-in type names (same vocabulary as ubwoko).
+   * Built-in names: number string boolean object urutonde fn native-fn.
+   * (ubwoko still prints raw tags; annotations treat fn and native-fn alike.)
    */
   private parse_type_annotation(): TypeAnnotation | undefined {
     if (this.at().type !== TokenType.COLON) return undefined;

--- a/src/parser/parser.ts
+++ b/src/parser/parser.ts
@@ -31,7 +31,14 @@ import {
   mkUnary,
   mkVarDecl,
   Identifier,
+  TypeAnnotation,
 } from './ast';
+import {
+  BUILTIN_TYPE_NAMES,
+  isBuiltinTypeName,
+  resolveTypeSafetyMode,
+  TypeSafetyMode,
+} from '../runtime/types';
 
 export interface Diagnostic {
   severity: 'error' | 'warning';
@@ -41,6 +48,8 @@ export interface Diagnostic {
 export interface ParseResult {
   program: Program;
   diagnostics: Diagnostic[];
+  /** Effective type-safety mode for this source (directive / env / default). */
+  typeSafety: TypeSafetyMode;
 }
 
 /**
@@ -57,6 +66,10 @@ export default class Parser {
   /** When true, the first error is thrown (produceAST). When false, recover. */
   private throwOnError = true;
   private source = '';
+  /** Resolved after source is known; used for strict-mode annotation requirements. */
+  private typeSafety: TypeSafetyMode = 'on';
+  /** Optional CLI/host override for type safety (set before parse). */
+  private typeSafetyOverride: string | null | undefined;
 
   private not_eof(): boolean {
     return this.at().type != TokenType.EOF;
@@ -119,6 +132,14 @@ export default class Parser {
   }
 
   /**
+   * Host/CLI override for type-safety mode (`on` | `off` | `strict`).
+   * Takes precedence over file `# kin-types:` and `KIN_TYPES`.
+   */
+  public setTypeSafetyOverride(mode: string | null | undefined): void {
+    this.typeSafetyOverride = mode;
+  }
+
+  /**
    * Backwards-compatible entry: throws on the first error.
    * Existing callers and tests keep this behaviour.
    */
@@ -139,6 +160,11 @@ export default class Parser {
     return this.parseInternal(sourceCodes, false);
   }
 
+  /** Last resolved type-safety mode (after produceAST/parse). */
+  public getTypeSafety(): TypeSafetyMode {
+    return this.typeSafety;
+  }
+
   private parseInternal(
     sourceCodes: string,
     throwOnError: boolean,
@@ -148,6 +174,10 @@ export default class Parser {
     this.diagnostics = [];
     this.pos = 0;
     this.loopDepth = 0;
+    this.typeSafety = resolveTypeSafetyMode(
+      sourceCodes,
+      this.typeSafetyOverride,
+    );
 
     const lexer = new Lexer(sourceCodes);
     this.tokens = lexer.tokenize();
@@ -173,6 +203,7 @@ export default class Parser {
     return {
       program: mkProgram(body, span),
       diagnostics: this.diagnostics,
+      typeSafety: this.typeSafety,
     };
   }
 
@@ -372,11 +403,60 @@ export default class Parser {
     return body;
   }
 
+  /**
+   * Optional type annotation after a binding name:
+   *   : number
+   *   : string?
+   * Names must be built-in type names (same vocabulary as ubwoko).
+   */
+  private parse_type_annotation(): TypeAnnotation | undefined {
+    if (this.at().type !== TokenType.COLON) return undefined;
+
+    this.eat(); // :
+    const typeTok = this.expect(TokenType.IDENTIFIER, 'type name');
+    // Hyphenated names (e.g. native-fn): lexer splits on `-`.
+    let name = typeTok.lexeme;
+    let endTok = typeTok;
+    while (this.at().type === TokenType.MINUS) {
+      this.eat();
+      const part = this.expect(TokenType.IDENTIFIER, 'type name');
+      name = `${name}-${part.lexeme}`;
+      endTok = part;
+    }
+
+    if (!isBuiltinTypeName(name)) {
+      this.fail(
+        'K032',
+        mergeSpans(tokenSpan(typeTok), tokenSpan(endTok)),
+        { name, allowed: BUILTIN_TYPE_NAMES.join(', ') },
+        `Unknown type name '${name}'. Expected one of: ${BUILTIN_TYPE_NAMES.join(', ')}`,
+      );
+    }
+
+    let optional = false;
+    if (this.at().type === TokenType.QUESTION) {
+      this.eat();
+      optional = true;
+    }
+
+    return { name, optional };
+  }
+
   private parse_var_declaration(): Stmt {
     const startTok = this.at();
     const isConstant = this.eat().type == TokenType.NTAHINDUKA;
     const nameTok = this.expect(TokenType.IDENTIFIER, 'variable name');
     const identifier = nameTok.lexeme;
+    const typeAnnotation = this.parse_type_annotation();
+
+    if (this.typeSafety === 'strict' && !typeAnnotation) {
+      this.fail(
+        'K035',
+        tokenSpan(nameTok),
+        { name: identifier },
+        `Strict type safety requires a type annotation on '${identifier}'`,
+      );
+    }
 
     if (this.at().type == TokenType.SEMI_COLON) {
       const semi = this.eat();
@@ -393,16 +473,18 @@ export default class Parser {
         false,
         undefined,
         mergeSpans(tokenSpan(startTok), tokenSpan(semi)),
+        typeAnnotation,
       );
     }
 
-    this.eat(); // =
+    this.expect(TokenType.EQUAL, '=');
     const value = this.parse_expr();
     return mkVarDecl(
       identifier,
       isConstant,
       value,
       mergeSpans(tokenSpan(startTok), value.span),
+      typeAnnotation,
     );
   }
 

--- a/src/runtime/environment.ts
+++ b/src/runtime/environment.ts
@@ -5,8 +5,9 @@
  *******************************************************************************************/
 
 import { Interpreter } from '..';
-import { Identifier, MemberExpr } from '../parser/ast';
+import { Identifier, MemberExpr, TypeAnnotation } from '../parser/ast';
 import { createKinError } from '../lib/errors';
+import { Span } from '../lib/span';
 import {
   ArrayVal,
   MK_NATIVE_FN,
@@ -18,28 +19,61 @@ import {
   typeName,
 } from './values';
 import { lookupMethod } from './methods';
+import {
+  assertValueMatchesType,
+  TypeSafetyMode,
+} from './types';
 
 export default class Environment {
   private parent?: Environment;
   private variables: Map<string, RuntimeVal>;
   private constants: Set<string>;
+  /** Type annotations for variables declared with `: type` / `: type?`. */
+  private types: Map<string, TypeAnnotation>;
+  /**
+   * Type-safety mode for this program. Child scopes inherit the root mode.
+   * Only meaningful on the global env; nested envs read through the root.
+   */
+  private typeSafety: TypeSafetyMode;
 
-  constructor(parentENV?: Environment) {
+  constructor(parentENV?: Environment, typeSafety: TypeSafetyMode = 'on') {
     this.parent = parentENV;
     this.variables = new Map();
     this.constants = new Set();
+    this.types = new Map();
+    this.typeSafety = parentENV ? parentENV.typeSafety : typeSafety;
+  }
+
+  public getTypeSafety(): TypeSafetyMode {
+    return this.typeSafety;
+  }
+
+  /**
+   * Update type-safety mode (e.g. REPL after a `# kin-types:` line).
+   * Nested scopes created later inherit via the constructor copy.
+   */
+  public setTypeSafety(mode: TypeSafetyMode): void {
+    this.typeSafety = mode;
   }
 
   public declareVar(
     varname: string,
     value: RuntimeVal,
     constant: boolean,
+    typeAnnotation?: TypeAnnotation,
+    span?: Span,
   ): RuntimeVal {
     if (this.variables.has(varname)) {
       throw createKinError('K007', {
         params: { name: varname },
         message: `Cannot declare variable ${varname}. As it already is defined.`,
       });
+    }
+
+    // `off` ignores annotations; `on`/`strict` check and store them.
+    if (typeAnnotation && this.typeSafety !== 'off') {
+      assertValueMatchesType(value, typeAnnotation, varname, span);
+      this.types.set(varname, typeAnnotation);
     }
 
     this.variables.set(varname, value);
@@ -49,7 +83,11 @@ export default class Environment {
     return value;
   }
 
-  public assignVar(varname: string, value: RuntimeVal): RuntimeVal {
+  public assignVar(
+    varname: string,
+    value: RuntimeVal,
+    span?: Span,
+  ): RuntimeVal {
     const env = this.resolve(varname);
 
     if (env.constants.has(varname)) {
@@ -59,9 +97,21 @@ export default class Environment {
       });
     }
 
+    if (this.typeSafety !== 'off') {
+      const annotation = env.types.get(varname);
+      if (annotation) {
+        assertValueMatchesType(value, annotation, varname, span);
+      }
+    }
+
     env.variables.set(varname, value);
 
     return value;
+  }
+
+  /** Look up a variable's type annotation, if any (for hosts / tests). */
+  public lookupType(varname: string): TypeAnnotation | undefined {
+    return this.resolve(varname).types.get(varname);
   }
 
   public lookupMember(expr: MemberExpr): RuntimeVal {

--- a/src/runtime/environment.ts
+++ b/src/runtime/environment.ts
@@ -31,8 +31,8 @@ export default class Environment {
   /** Type annotations for variables declared with `: type` / `: type?`. */
   private types: Map<string, TypeAnnotation>;
   /**
-   * Type-safety mode for this program. Child scopes inherit the root mode.
-   * Only meaningful on the global env; nested envs read through the root.
+   * Type-safety mode for this program. Nested scopes **copy** the parent's
+   * mode at construction time (not a live root lookup).
    */
   private typeSafety: TypeSafetyMode;
 

--- a/src/runtime/eval/expressions.ts
+++ b/src/runtime/eval/expressions.ts
@@ -138,7 +138,11 @@ export default class EvalExpr {
     }
 
     const varname = (node.assigne as Identifier).symbol;
-    return env.assignVar(varname, Interpreter.evaluate(node.value, env));
+    return env.assignVar(
+      varname,
+      Interpreter.evaluate(node.value, env),
+      node.span,
+    );
   }
 
   public static eval_object_expr(

--- a/src/runtime/eval/statements.ts
+++ b/src/runtime/eval/statements.ts
@@ -75,11 +75,28 @@ export default class EvalStmt {
     declaration: VariableDeclaration,
     env: Environment,
   ): RuntimeVal {
+    if (
+      env.getTypeSafety() === 'strict' &&
+      !declaration.typeAnnotation
+    ) {
+      throw createKinError('K035', {
+        span: declaration.span,
+        params: { name: declaration.identifier },
+        message: `Strict type safety requires a type annotation on '${declaration.identifier}'`,
+      });
+    }
+
     const value = declaration.value
       ? Interpreter.evaluate(declaration.value, env)
       : MK_NULL();
 
-    return env.declareVar(declaration.identifier, value, declaration.constant);
+    return env.declareVar(
+      declaration.identifier,
+      value,
+      declaration.constant,
+      declaration.typeAnnotation,
+      declaration.span,
+    );
   }
 
   public static eval_conditional_statement(

--- a/src/runtime/globals.ts
+++ b/src/runtime/globals.ts
@@ -17,9 +17,28 @@ import { createKinIgihe } from './in-built/time';
 import { createKinUrutonde } from './in-built/arrays';
 import { createKinInyandiko } from './in-built/files';
 import { ubwoko } from './in-built/types';
+import {
+  normalizeTypeSafetyMode,
+  TypeSafetyMode,
+} from './types';
 
-export function createGlobalEnv(filename: string): Environment {
-  const env = new Environment();
+export interface GlobalEnvOptions {
+  /**
+   * Type-safety mode for this run.
+   * When omitted, uses `KIN_TYPES` env if valid, otherwise `on`.
+   * File `# kin-types:` is applied by hosts that pass `ParseResult.typeSafety`
+   * (see `runSource`).
+   */
+  typeSafety?: TypeSafetyMode;
+}
+
+export function createGlobalEnv(
+  filename: string,
+  options: GlobalEnvOptions = {},
+): Environment {
+  const fromEnv = normalizeTypeSafetyMode(process.env.KIN_TYPES);
+  const typeSafety = options.typeSafety ?? fromEnv ?? 'on';
+  const env = new Environment(undefined, typeSafety);
   env.declareVar('filename', MK_STRING(filename), true);
   env.declareVar('nibyo', MK_BOOL(true), true);
   env.declareVar('sibyo', MK_BOOL(false), true);

--- a/src/runtime/run.ts
+++ b/src/runtime/run.ts
@@ -1,0 +1,95 @@
+/********************************************************************************
+ *                         Run a Kin source string                              *
+ *   Single entry that keeps parser type-safety mode in sync with the env       *
+ ********************************************************************************/
+
+import Parser, { Diagnostic, ParseResult } from '../parser/parser';
+import { Interpreter } from './interpreter';
+import { createGlobalEnv } from './globals';
+import Environment from './environment';
+import { RuntimeVal } from './values';
+import { TypeSafetyMode } from './types';
+import { createKinError } from '../lib/errors';
+
+export interface RunSourceOptions {
+  filename?: string;
+  /** CLI / host override: on | off | strict */
+  typeSafety?: string | null;
+  /**
+   * When true (default), throw the first diagnostic instead of returning them.
+   * Set false to get ParseResult-style diagnostics without evaluating on error.
+   */
+  throwOnDiagnostic?: boolean;
+}
+
+export interface RunSourceResult {
+  result: RuntimeVal;
+  env: Environment;
+  typeSafety: TypeSafetyMode;
+  diagnostics: Diagnostic[];
+  program: ParseResult['program'];
+}
+
+/**
+ * Parse and evaluate source with a single resolved type-safety mode shared
+ * by the parser (strict annotations) and the environment (runtime checks).
+ *
+ * Prefer this over calling produceAST + createGlobalEnv separately so
+ * `# kin-types:` / `KIN_TYPES` / overrides cannot drift between the two.
+ */
+export function runSource(
+  source: string,
+  options: RunSourceOptions = {},
+): RunSourceResult {
+  const filename = options.filename ?? 'program.kin';
+  const throwOnDiagnostic = options.throwOnDiagnostic !== false;
+
+  const parser = new Parser();
+  if (options.typeSafety !== undefined) {
+    parser.setTypeSafetyOverride(options.typeSafety);
+  }
+
+  const { program, diagnostics, typeSafety } = parser.parse(source);
+
+  if (diagnostics.length > 0 && throwOnDiagnostic) {
+    throw diagnostics[0].error;
+  }
+
+  const env = createGlobalEnv(filename, { typeSafety });
+
+  if (diagnostics.length > 0) {
+    return {
+      result: env.lookupVar('ubusa'),
+      env,
+      typeSafety,
+      diagnostics,
+      program,
+    };
+  }
+
+  const result = Interpreter.evaluate(program, env);
+  return { result, env, typeSafety, diagnostics, program };
+}
+
+/**
+ * Apply a newly parsed line's type-safety mode onto an existing env
+ * (used by the REPL so `# kin-types:` takes effect without wiping bindings).
+ */
+export function applyTypeSafetyToEnv(
+  env: Environment,
+  typeSafety: TypeSafetyMode,
+): void {
+  env.setTypeSafety(typeSafety);
+}
+
+/** Guard for hosts that forget to pass typeSafety into createGlobalEnv. */
+export function assertTypeSafetyAligned(
+  parserMode: TypeSafetyMode,
+  env: Environment,
+): void {
+  if (parserMode !== env.getTypeSafety()) {
+    throw createKinError('K026', {
+      message: `Type-safety mode mismatch: parser=${parserMode}, env=${env.getTypeSafety()}`,
+    });
+  }
+}

--- a/src/runtime/run.ts
+++ b/src/runtime/run.ts
@@ -9,7 +9,6 @@ import { createGlobalEnv } from './globals';
 import Environment from './environment';
 import { RuntimeVal } from './values';
 import { TypeSafetyMode } from './types';
-import { createKinError } from '../lib/errors';
 
 export interface RunSourceOptions {
   filename?: string;
@@ -80,16 +79,4 @@ export function applyTypeSafetyToEnv(
   typeSafety: TypeSafetyMode,
 ): void {
   env.setTypeSafety(typeSafety);
-}
-
-/** Guard for hosts that forget to pass typeSafety into createGlobalEnv. */
-export function assertTypeSafetyAligned(
-  parserMode: TypeSafetyMode,
-  env: Environment,
-): void {
-  if (parserMode !== env.getTypeSafety()) {
-    throw createKinError('K026', {
-      message: `Type-safety mode mismatch: parser=${parserMode}, env=${env.getTypeSafety()}`,
-    });
-  }
 }

--- a/src/runtime/types.ts
+++ b/src/runtime/types.ts
@@ -1,0 +1,161 @@
+/********************************************************************************
+ *                         Variable type annotations                            *
+ *   Runtime checks for optional type annotations on reka / ntahinduka          *
+ ********************************************************************************/
+
+import { TypeAnnotation } from '../parser/ast';
+import { createKinError } from '../lib/errors';
+import { Span } from '../lib/span';
+import { RuntimeVal } from './values';
+
+/**
+ * Type-safety mode for a program.
+ * - `on` (default): annotated bindings are checked; unannotated stay dynamic
+ * - `off`: annotations are ignored (type safety disabled)
+ * - `strict`: every reka/ntahinduka must have a type annotation
+ *
+ * Resolution order: CLI `--types` > file `# kin-types:` directive > `KIN_TYPES` env > `on`
+ */
+export type TypeSafetyMode = 'on' | 'off' | 'strict';
+
+const TYPE_SAFETY_MODES = new Set<TypeSafetyMode>(['on', 'off', 'strict']);
+
+/** Built-in type names accepted in annotations. */
+export const BUILTIN_TYPE_NAMES = [
+  'number',
+  'string',
+  'boolean',
+  'object',
+  'urutonde',
+  'fn',
+  'native-fn',
+] as const;
+
+export type BuiltinTypeName = (typeof BUILTIN_TYPE_NAMES)[number];
+
+const BUILTIN_SET = new Set<string>(BUILTIN_TYPE_NAMES);
+
+/**
+ * File directive: `# kin-types: on|off|strict` (case-insensitive).
+ * Last matching directive in the file wins.
+ */
+const KIN_TYPES_DIRECTIVE = /^\s*#\s*kin-types\s*:\s*(on|off|strict)\s*$/i;
+
+export function isBuiltinTypeName(name: string): name is BuiltinTypeName {
+  return BUILTIN_SET.has(name);
+}
+
+/** Normalize a type name for checking (`native-fn` aliases to `fn`). */
+export function normalizeAnnotationName(name: string): string {
+  if (name === 'native-fn') return 'fn';
+  return name;
+}
+
+/**
+ * Map a runtime value to its annotation type name.
+ * User functions and native functions both report as `fn` for annotations
+ * (ubwoko still prints `fn` vs `native-fn` as the raw runtime tag).
+ */
+export function annotationTypeName(value: RuntimeVal): string {
+  if (value.type === 'array') return 'urutonde';
+  if (value.type === 'native-fn' || value.type === 'fn') return 'fn';
+  if (value.type === 'null') return 'null';
+  return value.type;
+}
+
+/** Whether a value satisfies the annotation (including optional null). */
+export function valueMatchesType(
+  value: RuntimeVal,
+  annotation: TypeAnnotation,
+): boolean {
+  if (value.type === 'null') {
+    return annotation.optional;
+  }
+  return annotationTypeName(value) === normalizeAnnotationName(annotation.name);
+}
+
+/** Format for display: `number` or `number?`. */
+export function formatTypeAnnotation(annotation: TypeAnnotation): string {
+  const name = normalizeAnnotationName(annotation.name);
+  return annotation.optional ? `${name}?` : name;
+}
+
+/**
+ * Throw if the value does not match the annotation.
+ * Used on declaration and reassignment when type safety is not `off`.
+ */
+export function assertValueMatchesType(
+  value: RuntimeVal,
+  annotation: TypeAnnotation,
+  varname: string,
+  span?: Span,
+): void {
+  if (valueMatchesType(value, annotation)) return;
+
+  const expectedName = normalizeAnnotationName(annotation.name);
+  const got = annotationTypeName(value);
+
+  if (value.type === 'null' && !annotation.optional) {
+    throw createKinError('K034', {
+      span,
+      params: {
+        name: varname,
+        expected: expectedName,
+      },
+      message: `Variable '${varname}' has required type ${expectedName} and cannot be ubusa`,
+    });
+  }
+
+  // K033: report the base type name; optional is a separate concern (nullability).
+  throw createKinError('K033', {
+    span,
+    params: {
+      name: varname,
+      expected: expectedName,
+      got,
+    },
+    message: `Variable '${varname}' expects type ${expectedName}, got ${got}`,
+  });
+}
+
+export function normalizeTypeSafetyMode(
+  raw: string | null | undefined,
+): TypeSafetyMode | undefined {
+  if (raw == null || raw === '') return undefined;
+  const mode = raw.trim().toLowerCase() as TypeSafetyMode;
+  return TYPE_SAFETY_MODES.has(mode) ? mode : undefined;
+}
+
+/** Last `# kin-types: on|off|strict` comment in the source, if any. */
+export function parseTypeSafetyDirective(
+  source: string,
+): TypeSafetyMode | undefined {
+  let found: TypeSafetyMode | undefined;
+  for (const line of source.split(/\r?\n/)) {
+    const m = line.match(KIN_TYPES_DIRECTIVE);
+    if (m) {
+      found = m[1].toLowerCase() as TypeSafetyMode;
+    }
+  }
+  return found;
+}
+
+/**
+ * Resolve effective type-safety mode.
+ * Precedence: explicit override > file `# kin-types:` > `KIN_TYPES` env > `on`.
+ */
+export function resolveTypeSafetyMode(
+  source: string,
+  override?: string | null,
+): TypeSafetyMode {
+  const fromOverride = normalizeTypeSafetyMode(override ?? undefined);
+  if (fromOverride) return fromOverride;
+
+  const fromFile = parseTypeSafetyDirective(source);
+  if (fromFile) return fromFile;
+
+  const fromEnv = normalizeTypeSafetyMode(process.env.KIN_TYPES);
+  if (fromEnv) return fromEnv;
+
+  return 'on';
+}

--- a/tests/examples.test.ts
+++ b/tests/examples.test.ts
@@ -2,9 +2,7 @@ import { readdirSync, readFileSync } from 'fs';
 import path from 'path';
 import { afterEach, beforeEach, describe, expect, test, vi } from 'vitest';
 import * as log from '../src/lib/log';
-import Parser from '../src/parser/parser';
-import { Interpreter } from '../src/runtime/interpreter';
-import { createGlobalEnv } from '../src/runtime/globals';
+import { runSource } from '../src/runtime/run';
 
 const promptAnswers = vi.hoisted(() => ({
   queue: [] as Array<string | null>,
@@ -30,10 +28,8 @@ const EXAMPLE_INPUTS: Record<string, string[]> = {
 function runExample(filename: string): void {
   const filePath = path.join(EXAMPLES_DIR, filename);
   const source = readFileSync(filePath, 'utf-8');
-  const parser = new Parser();
-  const ast = parser.produceAST(source);
-  const env = createGlobalEnv(filePath);
-  Interpreter.evaluate(ast, env);
+  // runSource keeps parser + env type-safety modes aligned.
+  runSource(source, { filename: filePath });
 }
 
 describe('Example programs (current language implementation)', () => {
@@ -61,6 +57,7 @@ describe('Example programs (current language implementation)', () => {
         'loops.kin',
         'objects.kin',
         'switch.kin',
+        'types.kin',
       ]),
     );
   });

--- a/tests/helpers.ts
+++ b/tests/helpers.ts
@@ -1,6 +1,4 @@
 import Parser from '../src/parser/parser';
-import { Interpreter } from '../src/runtime/interpreter';
-import { createGlobalEnv } from '../src/runtime/globals';
 import {
   ArrayVal,
   BooleanVal,
@@ -12,15 +10,18 @@ import {
 } from '../src/runtime/values';
 import Environment from '../src/runtime/environment';
 import { KinError } from '../src/lib/errors';
+import { TypeSafetyMode } from '../src/runtime/types';
+import { runSource } from '../src/runtime/run';
 
 export function evaluate(
   sourceCode: string,
   filename = 'test.kin',
+  options: { typeSafety?: TypeSafetyMode | string } = {},
 ): { result: RuntimeVal; env: Environment } {
-  const parser = new Parser();
-  const ast = parser.produceAST(sourceCode);
-  const env = createGlobalEnv(filename);
-  const result = Interpreter.evaluate(ast, env);
+  const { result, env } = runSource(sourceCode, {
+    filename,
+    typeSafety: options.typeSafety,
+  });
   return { result, env };
 }
 

--- a/tests/types.test.ts
+++ b/tests/types.test.ts
@@ -1,0 +1,418 @@
+import { describe, test, expect, afterEach } from 'vitest';
+import Lexer from '../src/lexer/lexer';
+import Parser from '../src/parser/parser';
+import TokenType from '../src/lexer/tokens';
+import {
+  asNumber,
+  asString,
+  evaluate,
+  expectKinError,
+} from './helpers';
+import { KinSyntaxError, KinTypeError } from '../src/lib/errors';
+import {
+  parseTypeSafetyDirective,
+  resolveTypeSafetyMode,
+} from '../src/runtime/types';
+import { applyTypeSafetyToEnv, runSource } from '../src/runtime/run';
+import { createGlobalEnv } from '../src/runtime/globals';
+import { Interpreter } from '../src/runtime/interpreter';
+
+/** Drop span fields so structural AST tests stay readable. */
+function stripSpans(node: unknown): unknown {
+  if (Array.isArray(node)) return node.map(stripSpans);
+  if (node && typeof node === 'object') {
+    const out: Record<string, unknown> = {};
+    for (const [k, v] of Object.entries(node as Record<string, unknown>)) {
+      if (k === 'span') continue;
+      out[k] = stripSpans(v);
+    }
+    return out;
+  }
+  return node;
+}
+
+function parse(source: string, typeSafety?: string) {
+  const parser = new Parser();
+  if (typeSafety !== undefined) parser.setTypeSafetyOverride(typeSafety);
+  return stripSpans(parser.produceAST(source));
+}
+
+describe('Variable type annotations', () => {
+  const prevKinTypes = process.env.KIN_TYPES;
+  afterEach(() => {
+    if (prevKinTypes === undefined) delete process.env.KIN_TYPES;
+    else process.env.KIN_TYPES = prevKinTypes;
+  });
+
+  describe('lexer', () => {
+    test('tokenizes ? as QUESTION', () => {
+      const tokens = new Lexer('reka x: number? = 1').tokenize();
+      const types = tokens.map((t) => t.type);
+      expect(types).toContain(TokenType.COLON);
+      expect(types).toContain(TokenType.QUESTION);
+      expect(tokens.find((t) => t.type === TokenType.QUESTION)?.lexeme).toBe(
+        '?',
+      );
+    });
+  });
+
+  describe('parser', () => {
+    test('parses required type annotation', () => {
+      expect(parse('reka age: number = 25')).toEqual({
+        kind: 'Program',
+        body: [
+          {
+            kind: 'VariableDeclaration',
+            constant: false,
+            identifier: 'age',
+            typeAnnotation: { name: 'number', optional: false },
+            value: { kind: 'NumericLiteral', value: 25 },
+          },
+        ],
+      });
+    });
+
+    test('parses optional type annotation', () => {
+      expect(parse('reka score: number? = ubusa')).toEqual({
+        kind: 'Program',
+        body: [
+          {
+            kind: 'VariableDeclaration',
+            constant: false,
+            identifier: 'score',
+            typeAnnotation: { name: 'number', optional: true },
+            value: { kind: 'Identifier', symbol: 'ubusa' },
+          },
+        ],
+      });
+    });
+
+    test('parses optional type with omitted initializer', () => {
+      expect(parse('reka maybe: string?;')).toEqual({
+        kind: 'Program',
+        body: [
+          {
+            kind: 'VariableDeclaration',
+            constant: false,
+            identifier: 'maybe',
+            typeAnnotation: { name: 'string', optional: true },
+            value: undefined,
+          },
+        ],
+      });
+    });
+
+    test('parses typed constant', () => {
+      expect(parse('ntahinduka name: string = "Keza"')).toEqual({
+        kind: 'Program',
+        body: [
+          {
+            kind: 'VariableDeclaration',
+            constant: true,
+            identifier: 'name',
+            typeAnnotation: { name: 'string', optional: false },
+            value: { kind: 'StringLiteral', value: 'Keza' },
+          },
+        ],
+      });
+    });
+
+    test('accepts native-fn as a synonym of fn', () => {
+      expect(parse('reka f: native-fn = tangaza_amakuru')).toEqual({
+        kind: 'Program',
+        body: [
+          {
+            kind: 'VariableDeclaration',
+            constant: false,
+            identifier: 'f',
+            typeAnnotation: { name: 'native-fn', optional: false },
+            value: { kind: 'Identifier', symbol: 'tangaza_amakuru' },
+          },
+        ],
+      });
+    });
+
+    test('rejects unknown type name (K032)', () => {
+      try {
+        new Parser().produceAST('reka x: foo = 1');
+        throw new Error('expected throw');
+      } catch (e) {
+        expect((e as { code?: string }).code).toBe('K032');
+      }
+    });
+
+    test('unannotated declaration omits typeAnnotation field', () => {
+      const ast = parse('reka x = 1') as {
+        body: Array<Record<string, unknown>>;
+      };
+      expect(ast.body[0]).not.toHaveProperty('typeAnnotation');
+    });
+
+    test('strict mode rejects untyped reka at parse time (K035)', () => {
+      try {
+        parse('reka x = 1', 'strict');
+        throw new Error('expected throw');
+      } catch (e) {
+        expect(e).toBeInstanceOf(KinSyntaxError);
+        expect((e as { code?: string }).code).toBe('K035');
+      }
+    });
+  });
+
+  describe('type-safety modes', () => {
+    test('parses # kin-types directive (last wins)', () => {
+      expect(parseTypeSafetyDirective('# kin-types: off\nreka x = 1')).toBe(
+        'off',
+      );
+      expect(
+        parseTypeSafetyDirective(
+          '# kin-types: on\n# kin-types: strict\nreka x: number = 1',
+        ),
+      ).toBe('strict');
+    });
+
+    test('resolveTypeSafetyMode precedence: override > file > env > on', () => {
+      process.env.KIN_TYPES = 'strict';
+      expect(resolveTypeSafetyMode('reka x = 1')).toBe('strict');
+      expect(resolveTypeSafetyMode('# kin-types: off\nreka x = 1')).toBe(
+        'off',
+      );
+      expect(
+        resolveTypeSafetyMode('# kin-types: off\nreka x = 1', 'on'),
+      ).toBe('on');
+      delete process.env.KIN_TYPES;
+      expect(resolveTypeSafetyMode('reka x = 1')).toBe('on');
+    });
+
+    test('off mode ignores annotations (no type check)', () => {
+      const { env } = evaluate(
+        `
+        # kin-types: off
+        reka x: number = "not a number"
+        x = {a: 1}
+      `,
+      );
+      expect(env.lookupVar('x').type).toBe('object');
+      expect(env.lookupType('x')).toBeUndefined();
+      expect(env.getTypeSafety()).toBe('off');
+    });
+
+    test('strict mode accepts fully typed program', () => {
+      const { env } = evaluate(
+        `
+        # kin-types: strict
+        reka n: number = 1
+        reka s: string? = ubusa
+      `,
+      );
+      expect(asNumber(env.lookupVar('n'))).toBe(1);
+      expect(env.getTypeSafety()).toBe('strict');
+    });
+
+    test('CLI-style override forces strict over file off', () => {
+      expect(() =>
+        evaluate('# kin-types: off\nreka x = 1', 'test.kin', {
+          typeSafety: 'strict',
+        }),
+      ).toThrow();
+    });
+  });
+
+  describe('runtime', () => {
+    test('required type accepts matching value', () => {
+      const { env } = evaluate('reka age: number = 30');
+      expect(asNumber(env.lookupVar('age'))).toBe(30);
+      expect(env.lookupType('age')).toEqual({
+        name: 'number',
+        optional: false,
+      });
+    });
+
+    test('optional type accepts ubusa and a real value', () => {
+      const { env } = evaluate(`
+        reka a: number? = ubusa
+        reka b: string? = "hi"
+        reka c: boolean?;
+      `);
+      expect(env.lookupVar('a').type).toBe('null');
+      expect(asString(env.lookupVar('b'))).toBe('hi');
+      expect(env.lookupVar('c').type).toBe('null');
+      expect(env.lookupType('c')?.optional).toBe(true);
+    });
+
+    test('required type rejects ubusa on declare (K034)', () => {
+      const err = expectKinError('reka x: number;', 'K034');
+      expect(err).toBeInstanceOf(KinTypeError);
+      expect(err.ERRCODE).toBe('E_TYPE');
+    });
+
+    test('required type rejects explicit ubusa initializer (K034)', () => {
+      expectKinError('reka x: number = ubusa', 'K034');
+    });
+
+    test('required type rejects wrong type on declare (K033)', () => {
+      const err = expectKinError('reka x: number = "nope"', 'K033');
+      expect(err).toBeInstanceOf(KinTypeError);
+      expect(err.params.expected).toBe('number');
+      expect(err.params.got).toBe('string');
+    });
+
+    test('K033 for optional type reports base type name without ?', () => {
+      const err = expectKinError('reka x: number? = "a"', 'K033');
+      expect(err.params.expected).toBe('number');
+      expect(err.message).not.toMatch(/number\?/);
+    });
+
+    test('reassignment is checked against the annotation', () => {
+      expectKinError(
+        `
+        reka x: number = 1
+        x = "string"
+      `,
+        'K033',
+      );
+
+      expectKinError(
+        `
+        reka x: number = 1
+        x = ubusa
+      `,
+        'K034',
+      );
+
+      const { env } = evaluate(`
+        reka x: number? = 1
+        x = ubusa
+        reka y: number = 5
+        y = 10
+      `);
+      expect(env.lookupVar('x').type).toBe('null');
+      expect(asNumber(env.lookupVar('y'))).toBe(10);
+    });
+
+    test('reassignment inside niba is still type-checked', () => {
+      expectKinError(
+        `
+        reka x: number = 1
+        niba (nibyo) {
+          x = "bad"
+        }
+      `,
+        'K033',
+      );
+    });
+
+    test('optional type still rejects wrong non-null type', () => {
+      expectKinError(
+        `
+        reka x: number? = 1
+        x = "no"
+      `,
+        'K033',
+      );
+    });
+
+    test('ntahinduka wrong type fails (K033)', () => {
+      expectKinError('ntahinduka x: number = "no"', 'K033');
+    });
+
+    test('unannotated variables remain dynamic', () => {
+      const { env } = evaluate(`
+        reka x = 1
+        x = "now a string"
+      `);
+      expect(asString(env.lookupVar('x'))).toBe('now a string');
+      expect(env.lookupType('x')).toBeUndefined();
+    });
+
+    test('supports urutonde, object, boolean, and fn', () => {
+      const { env } = evaluate(`
+        reka list: urutonde = [1, 2]
+        reka bag: object = {a: 1}
+        reka ok: boolean = nibyo
+        porogaramu_ntoya add(a, b) { tanga a + b }
+        reka f: fn = add
+      `);
+      expect(env.lookupVar('list').type).toBe('array');
+      expect(env.lookupVar('bag').type).toBe('object');
+      expect(env.lookupVar('ok').type).toBe('boolean');
+      expect(env.lookupVar('f').type).toBe('fn');
+    });
+
+    test('fn annotation accepts native functions; got maps natives to fn', () => {
+      const { env } = evaluate('reka print: fn = tangaza_amakuru');
+      expect(env.lookupVar('print').type).toBe('native-fn');
+
+      // Wrong type: native assigned to number — got is annotation vocab "fn"
+      const err = expectKinError(
+        'reka n: number = tangaza_amakuru',
+        'K033',
+      );
+      expect(err.params.got).toBe('fn');
+    });
+
+    test('native-fn annotation accepts native functions', () => {
+      const { env } = evaluate('reka print: native-fn = tangaza_amakuru');
+      expect(env.lookupVar('print').type).toBe('native-fn');
+    });
+
+    test('all built-in type names work as required types', () => {
+      evaluate(`
+        reka n: number = 1
+        reka s: string = "a"
+        reka b: boolean = sibyo
+        reka o: object = {}
+        reka u: urutonde = []
+        reka f: fn = tangaza_amakuru
+        reka g: native-fn = tangaza_amakuru
+      `);
+    });
+
+    test('object literal colon coexists with type annotation', () => {
+      const { env } = evaluate(
+        'reka person: object = {izina: "Keza", imyaka: 20}',
+      );
+      expect(env.lookupVar('person').type).toBe('object');
+    });
+  });
+});
+
+describe('runSource / env mode alignment', () => {
+  const prev = process.env.KIN_TYPES;
+  afterEach(() => {
+    if (prev === undefined) delete process.env.KIN_TYPES;
+    else process.env.KIN_TYPES = prev;
+  });
+
+  test('runSource applies file # kin-types: off to env automatically', () => {
+    const { env, typeSafety } = runSource(`
+      # kin-types: off
+      reka x: number = "not a number"
+    `);
+    expect(typeSafety).toBe('off');
+    expect(env.getTypeSafety()).toBe('off');
+    expect(env.lookupVar('x').type).toBe('string');
+  });
+
+  test('createGlobalEnv honors KIN_TYPES=off when options omitted', () => {
+    process.env.KIN_TYPES = 'off';
+    const env = createGlobalEnv('t.kin');
+    expect(env.getTypeSafety()).toBe('off');
+  });
+
+  test('REPL-style applyTypeSafetyToEnv updates existing env', () => {
+    delete process.env.KIN_TYPES;
+    const env = createGlobalEnv('repl');
+    expect(env.getTypeSafety()).toBe('on');
+
+    const parser = new Parser();
+    const parsed = parser.parse(`
+      # kin-types: off
+      reka x: number = "ok when off"
+    `);
+    applyTypeSafetyToEnv(env, parsed.typeSafety);
+    expect(env.getTypeSafety()).toBe('off');
+    Interpreter.evaluate(parsed.program, env);
+    expect(env.lookupVar('x').type).toBe('string');
+  });
+});


### PR DESCRIPTION
## Summary

Variable type annotations (required / optional) and type-safety modes for [issue #256](https://github.com/kin-lang/kin/issues/256).

**Refs #256** — does **not** auto-close the issue.

### Syntax

```kin
reka age: number = 25
reka score: number? = ubusa
reka later: string?;
ntahinduka name: string = "Keza"
reka x = 1   # dynamic under default on mode
```

**Annotation names:** `number`, `string`, `boolean`, `object`, `urutonde`, `fn`, `native-fn` (synonym of `fn`).  
**ubwoko** still prints raw tags (`fn` vs `native-fn`); annotations treat both as `fn`.

### Type safety modes

| Mode | Meaning |
|------|---------|
| `on` (default) | Check annotated bindings; unannotated stay dynamic |
| `off` | Disable type safety (ignore annotations) |
| `strict` | Every `reka`/`ntahinduka` needs an annotation (K035) |

Precedence: CLI `--types` → `# kin-types: on\|off\|strict` → `KIN_TYPES` → `on`.

```bash
kin run --types strict file.kin
kin run --types off file.kin
KIN_TYPES=off kin run file.kin
```

Hosts should use **`runSource(source, opts)`** (exported) so parser and environment modes stay aligned. REPL applies `# kin-types:` per line via `applyTypeSafetyToEnv`.

### Errors

| Code | Meaning |
|------|---------|
| K032 | Unknown type name |
| K033 | Type mismatch |
| K034 | Required type cannot be `ubusa` |
| K035 | Strict mode missing annotation |

### Review fixes (cycles 1–2)

- Refs not Closes (history rewritten; no auto-close keywords)
- Full mode control: file + env + CLI; `runSource` + REPL wiring
- ubwoko vs annotation naming; `native-fn` hyphen parse
- Monorepo: wiki#25, vscode#11, editor#8

## Test plan

- [x] `npm test` — **256 passed**
- [x] `npx tsc --noEmit` — clean

## Monorepo follow-ups

| Package | PR |
|---------|-----|
| wiki | https://github.com/kin-lang/wiki/pull/25 |
| vscode-intellisense | https://github.com/kin-lang/vscode-intellisense/pull/11 |
| editor | https://github.com/kin-lang/editor/pull/8 |

## Later

- Parameter / return types
- User-defined types beyond `fn` / `object`