### PR TITLE
feat: native HTTP client via KIN_URUBUGA

### DIFF
--- a/examples/networking.kin
+++ b/examples/networking.kin
@@ -1,0 +1,17 @@
+# HTTP client example — KIN_URUBUGA.saba
+# Requires network access. Replace the URL with any public endpoint you trust.
+#
+# Success returns an object:
+#   res.kode     -> number  (HTTP status)
+#   res.umubiri  -> string  (response body)
+#   res.imitwe   -> object  (response headers, string values)
+# Failure (bad URL, timeout, DNS, …) returns an error message string.
+
+reka res = KIN_URUBUGA.saba("https://example.com")
+
+niba (ubwoko(res) == "string") {
+  tangaza_amakuru("Ikosa: ", res)
+} niba_byanze {
+  tangaza_amakuru("Kode: ", res.kode)
+  tangaza_amakuru("Umubiri (ibanze): ", res.umubiri)
+}

--- a/examples/networking.kin
+++ b/examples/networking.kin
@@ -1,11 +1,16 @@
 # HTTP client example — KIN_URUBUGA.saba
-# Requires network access. Replace the URL with any public endpoint you trust.
 #
 # Success returns an object:
-#   res.kode     -> number  (HTTP status)
-#   res.umubiri  -> string  (response body)
-#   res.imitwe   -> object  (response headers, string values)
+#   res.kode     -> number  (HTTP status; redirects are NOT followed)
+#   res.umubiri  -> string  (response body as UTF-8 text)
+#   res.imitwe   -> object  (response headers; keys use underscores, e.g. content_type)
 # Failure (bad URL, timeout, DNS, …) returns an error message string.
+#
+# Request headers: use underscores for hyphenated names (Content_Type -> Content-Type).
+#
+# Replace the URL with an endpoint you trust before running online demos.
+# Offline CI still "runs" this file: a transport failure returns a string and
+# the program does not throw.
 
 reka res = KIN_URUBUGA.saba("https://example.com")
 
@@ -13,5 +18,7 @@ niba (ubwoko(res) == "string") {
   tangaza_amakuru("Ikosa: ", res)
 } niba_byanze {
   tangaza_amakuru("Kode: ", res.kode)
+  # Header keys are underscore form so they work as Kin identifiers:
+  tangaza_amakuru("Content-Type: ", res.imitwe.content_type)
   tangaza_amakuru("Umubiri (ibanze): ", res.umubiri)
 }

--- a/src/runtime/globals.ts
+++ b/src/runtime/globals.ts
@@ -16,6 +16,7 @@ import { createKinAmagambo } from './in-built/strings';
 import { createKinIgihe } from './in-built/time';
 import { createKinUrutonde } from './in-built/arrays';
 import { createKinInyandiko } from './in-built/files';
+import { createKinUrubuga } from './in-built/network';
 import { ubwoko } from './in-built/types';
 
 export function createGlobalEnv(filename: string): Environment {
@@ -39,6 +40,7 @@ export function createGlobalEnv(filename: string): Environment {
   env.declareVar('KIN_URUTONDE', createKinUrutonde(), true);
   env.declareVar('ubwoko', ubwoko, true);
   env.declareVar('KIN_INYANDIKO', createKinInyandiko(), true);
+  env.declareVar('KIN_URUBUGA', createKinUrubuga(), true);
 
   return env;
 }

--- a/src/runtime/in-built/network.ts
+++ b/src/runtime/in-built/network.ts
@@ -19,6 +19,9 @@ import { createKinError } from '../../lib/errors';
 const DEFAULT_TIMEOUT_MS = 30_000;
 const MAX_BODY_BYTES = 20 * 1024 * 1024;
 
+/** Exported for tests that need a smaller ceiling without shipping a 20MiB payload. */
+export const NETWORK_MAX_BODY_BYTES = MAX_BODY_BYTES;
+
 export type HttpRequestResult =
   | {
       ok: true;
@@ -32,6 +35,9 @@ export type HttpRequestResult =
  * Perform a blocking HTTP(S) request.
  * Spawns a short-lived Node child so the main Kin interpreter stays synchronous
  * without deadlocking the event loop on http/https callbacks.
+ *
+ * Redirects are not followed — callers inspect `kode` (e.g. 302) and `imitwe`.
+ * Response bodies are decoded as UTF-8 text.
  */
 export function httpRequestSync(options: {
   method: string;
@@ -39,135 +45,169 @@ export function httpRequestSync(options: {
   body?: string;
   headers?: Record<string, string>;
   timeoutMs?: number;
+  /** Override response size limit (bytes). Used by tests; production default is MAX_BODY_BYTES. */
+  maxBodyBytes?: number;
 }): HttpRequestResult {
   const timeoutMs = options.timeoutMs ?? DEFAULT_TIMEOUT_MS;
+  const maxBodyBytes = options.maxBodyBytes ?? MAX_BODY_BYTES;
   const payload = JSON.stringify({
     method: options.method,
     url: options.url,
     body: options.body ?? '',
     headers: options.headers ?? {},
     timeoutMs,
+    maxBodyBytes,
   });
 
-  // Inline worker script: reads one JSON request from stdin, writes one JSON
-  // response to stdout. Kept as a string so we do not ship a separate file.
+  // Inline worker: one JSON request on stdin → exactly one JSON response on stdout.
+  // `respond()` is one-shot so timeout+error (or oversize+end) cannot concatenate payloads.
   const script = `
 const http = require('http');
 const https = require('https');
 const { URL } = require('url');
 
-let input = '';
-process.stdin.setEncoding('utf8');
-process.stdin.on('data', (c) => { input += c; });
-process.stdin.on('end', () => {
-  let opts;
+let responded = false;
+function respond(obj) {
+  if (responded) return;
+  responded = true;
   try {
-    opts = JSON.parse(input);
+    process.stdout.write(JSON.stringify(obj));
   } catch (e) {
-    process.stdout.write(JSON.stringify({ ok: false, error: 'Invalid request payload' }));
-    return;
-  }
-
-  let url;
-  try {
-    url = new URL(opts.url);
-  } catch (e) {
-    process.stdout.write(JSON.stringify({ ok: false, error: 'Invalid URL: ' + String(opts.url) }));
-    return;
-  }
-
-  if (url.protocol !== 'http:' && url.protocol !== 'https:') {
-    process.stdout.write(JSON.stringify({
-      ok: false,
-      error: 'Only http and https URLs are supported, got ' + url.protocol,
-    }));
-    return;
-  }
-
-  const lib = url.protocol === 'https:' ? https : http;
-  const method = String(opts.method || 'GET').toUpperCase();
-  const headers = Object.assign({}, opts.headers || {});
-  const body = opts.body == null ? '' : String(opts.body);
-  if (body !== '' && headers['Content-Length'] == null && headers['content-length'] == null) {
-    headers['Content-Length'] = Buffer.byteLength(body, 'utf8');
-  }
-
-  const req = lib.request(
-    {
-      protocol: url.protocol,
-      hostname: url.hostname,
-      port: url.port || (url.protocol === 'https:' ? 443 : 80),
-      path: url.pathname + url.search,
-      method,
-      headers,
-      timeout: opts.timeoutMs || ${DEFAULT_TIMEOUT_MS},
-    },
-    (res) => {
-      const chunks = [];
-      let total = 0;
-      res.on('data', (c) => {
-        total += c.length;
-        if (total > ${MAX_BODY_BYTES}) {
-          req.destroy();
-          process.stdout.write(JSON.stringify({
-            ok: false,
-            error: 'Response body exceeds maximum size',
-          }));
-          return;
-        }
-        chunks.push(c);
-      });
-      res.on('end', () => {
-        const respBody = Buffer.concat(chunks).toString('utf8');
-        const respHeaders = {};
-        for (const [k, v] of Object.entries(res.headers)) {
-          if (v == null) continue;
-          respHeaders[k] = Array.isArray(v) ? v.join(', ') : String(v);
-        }
-        process.stdout.write(JSON.stringify({
-          ok: true,
-          status: res.statusCode || 0,
-          body: respBody,
-          headers: respHeaders,
-        }));
-      });
-    },
-  );
-
-  req.on('timeout', () => {
-    req.destroy();
-    process.stdout.write(JSON.stringify({ ok: false, error: 'Request timed out' }));
-  });
-  req.on('error', (e) => {
+    // Last resort: avoid hanging the parent if stringify fails.
     process.stdout.write(JSON.stringify({
       ok: false,
       error: e && e.message ? e.message : String(e),
     }));
-  });
+  }
+  // Exit after a short tick so the write is flushed; also stops further events.
+  setImmediate(() => process.exit(0));
+}
 
-  if (body !== '') req.write(body, 'utf8');
-  req.end();
+function fail(message) {
+  respond({ ok: false, error: String(message) });
+}
+
+let input = '';
+process.stdin.setEncoding('utf8');
+process.stdin.on('data', (c) => { input += c; });
+process.stdin.on('end', () => {
+  try {
+    let opts;
+    try {
+      opts = JSON.parse(input);
+    } catch (e) {
+      fail('Invalid request payload');
+      return;
+    }
+
+    let url;
+    try {
+      url = new URL(opts.url);
+    } catch (e) {
+      fail('Invalid URL: ' + String(opts.url));
+      return;
+    }
+
+    if (url.protocol !== 'http:' && url.protocol !== 'https:') {
+      fail('Only http and https URLs are supported, got ' + url.protocol);
+      return;
+    }
+
+    const lib = url.protocol === 'https:' ? https : http;
+    const method = String(opts.method || 'GET').toUpperCase();
+    const headers = Object.assign({}, opts.headers || {});
+    const body = opts.body == null ? '' : String(opts.body);
+    const maxBody = Number(opts.maxBodyBytes) > 0 ? Number(opts.maxBodyBytes) : ${MAX_BODY_BYTES};
+    if (body !== '' && headers['Content-Length'] == null && headers['content-length'] == null) {
+      headers['Content-Length'] = Buffer.byteLength(body, 'utf8');
+    }
+
+    const req = lib.request(
+      {
+        protocol: url.protocol,
+        hostname: url.hostname,
+        port: url.port || (url.protocol === 'https:' ? 443 : 80),
+        path: url.pathname + url.search,
+        method,
+        headers,
+        timeout: opts.timeoutMs || ${DEFAULT_TIMEOUT_MS},
+      },
+      (res) => {
+        const chunks = [];
+        let total = 0;
+        let oversized = false;
+        res.on('data', (c) => {
+          if (oversized || responded) return;
+          total += c.length;
+          if (total > maxBody) {
+            oversized = true;
+            req.destroy();
+            fail('Response body exceeds maximum size');
+            return;
+          }
+          chunks.push(c);
+        });
+        res.on('end', () => {
+          if (responded || oversized) return;
+          const respBody = Buffer.concat(chunks).toString('utf8');
+          const respHeaders = {};
+          for (const [k, v] of Object.entries(res.headers)) {
+            if (v == null) continue;
+            // Kin object keys are identifiers: expose content-type as content_type.
+            const key = String(k).toLowerCase().replace(/-/g, '_');
+            respHeaders[key] = Array.isArray(v) ? v.join(', ') : String(v);
+          }
+          respond({
+            ok: true,
+            status: res.statusCode || 0,
+            body: respBody,
+            headers: respHeaders,
+          });
+        });
+      },
+    );
+
+    req.on('timeout', () => {
+      req.destroy();
+      fail('Request timed out');
+    });
+    req.on('error', (e) => {
+      // After destroy() Node often emits socket hang up — respond() ignores duplicates.
+      fail(e && e.message ? e.message : String(e));
+    });
+
+    if (body !== '') req.write(body, 'utf8');
+    req.end();
+  } catch (e) {
+    fail(e && e.message ? e.message : String(e));
+  }
 });
 `;
 
   const result = spawnSync(process.execPath, ['-e', script], {
     input: payload,
     encoding: 'utf-8',
-    maxBuffer: MAX_BODY_BYTES + 1024 * 1024,
+    maxBuffer: Math.max(maxBodyBytes, MAX_BODY_BYTES) + 1024 * 1024,
     timeout: timeoutMs + 5_000,
   });
 
   if (result.error) {
+    // spawnSync timeout surfaces as error.code === 'ETIMEDOUT'
+    if ((result.error as NodeJS.ErrnoException).code === 'ETIMEDOUT') {
+      return { ok: false, error: 'Request timed out' };
+    }
     return { ok: false, error: result.error.message };
   }
 
   const stdout = (result.stdout ?? '').trim();
   if (!stdout) {
     const stderr = (result.stderr ?? '').trim();
+    // Prefer a clean one-line message when Node dumped a stack to stderr.
+    const firstLine = stderr.split('\n').find((l) => l.trim().length > 0) ?? '';
     return {
       ok: false,
       error:
-        stderr ||
+        firstLine ||
         (result.status != null
           ? `Request process exited with code ${result.status}`
           : 'Empty response from HTTP helper'),
@@ -181,10 +221,26 @@ process.stdin.on('end', () => {
     }
     return { ok: false, error: 'Malformed response from HTTP helper' };
   } catch {
+    // If a buggy worker still double-wrote, try the first JSON object only.
+    const firstBrace = stdout.indexOf('{');
+    const secondBrace = stdout.indexOf('}{');
+    if (firstBrace === 0 && secondBrace > 0) {
+      try {
+        const first = JSON.parse(
+          stdout.slice(0, secondBrace + 1),
+        ) as HttpRequestResult;
+        if (first && typeof first === 'object' && 'ok' in first) {
+          return first;
+        }
+      } catch {
+        // fall through
+      }
+    }
     return {
       ok: false,
       error:
-        (result.stderr ?? '').trim() || 'Failed to parse HTTP helper output',
+        (result.stderr ?? '').trim().split('\n')[0] ||
+        'Failed to parse HTTP helper output',
     };
   }
 }
@@ -251,6 +307,7 @@ function responseObject(result: {
  *   - Default method is GET when only url is given.
  *   - Success: object { kode, umubiri, imitwe }
  *   - Failure (DNS, timeout, bad URL, …): error message string
+ *   - Redirects are not followed
  */
 export function createKinUrubuga(): ObjectVal {
   return MK_OBJECT(
@@ -258,7 +315,10 @@ export function createKinUrubuga(): ObjectVal {
       'saba',
       defineNative({
         name: 'KIN_URUBUGA.saba',
-        params: ['string'],
+        // Optional trailing args: minArgs 1, maxArgs 4. defineNative only auto-checks
+        // types for provided slots when params length matches; optional slots use 'any'
+        // and are validated below so callers can omit method/body/headers.
+        params: ['string', 'any', 'any', 'any'],
         minArgs: 1,
         maxArgs: 4,
         fn: (args) => {

--- a/src/runtime/in-built/network.ts
+++ b/src/runtime/in-built/network.ts
@@ -1,0 +1,313 @@
+/*************************************************************************************************************
+ *                                              KIN_URUBUGA                                                  *
+ *  Networking helpers. First slice: synchronous HTTP client (GET/POST/…) via Node http/https.               *
+ *  On transport failure returns an error message string (same pattern as KIN_INYANDIKO).                     *
+ *************************************************************************************************************/
+
+import { spawnSync } from 'child_process';
+import {
+  MK_NUMBER,
+  MK_OBJECT,
+  MK_STRING,
+  ObjectVal,
+  RuntimeVal,
+  StringVal,
+} from '../values';
+import { defineNative } from '../native';
+import { createKinError } from '../../lib/errors';
+
+const DEFAULT_TIMEOUT_MS = 30_000;
+const MAX_BODY_BYTES = 20 * 1024 * 1024;
+
+export type HttpRequestResult =
+  | {
+      ok: true;
+      status: number;
+      body: string;
+      headers: Record<string, string>;
+    }
+  | { ok: false; error: string };
+
+/**
+ * Perform a blocking HTTP(S) request.
+ * Spawns a short-lived Node child so the main Kin interpreter stays synchronous
+ * without deadlocking the event loop on http/https callbacks.
+ */
+export function httpRequestSync(options: {
+  method: string;
+  url: string;
+  body?: string;
+  headers?: Record<string, string>;
+  timeoutMs?: number;
+}): HttpRequestResult {
+  const timeoutMs = options.timeoutMs ?? DEFAULT_TIMEOUT_MS;
+  const payload = JSON.stringify({
+    method: options.method,
+    url: options.url,
+    body: options.body ?? '',
+    headers: options.headers ?? {},
+    timeoutMs,
+  });
+
+  // Inline worker script: reads one JSON request from stdin, writes one JSON
+  // response to stdout. Kept as a string so we do not ship a separate file.
+  const script = `
+const http = require('http');
+const https = require('https');
+const { URL } = require('url');
+
+let input = '';
+process.stdin.setEncoding('utf8');
+process.stdin.on('data', (c) => { input += c; });
+process.stdin.on('end', () => {
+  let opts;
+  try {
+    opts = JSON.parse(input);
+  } catch (e) {
+    process.stdout.write(JSON.stringify({ ok: false, error: 'Invalid request payload' }));
+    return;
+  }
+
+  let url;
+  try {
+    url = new URL(opts.url);
+  } catch (e) {
+    process.stdout.write(JSON.stringify({ ok: false, error: 'Invalid URL: ' + String(opts.url) }));
+    return;
+  }
+
+  if (url.protocol !== 'http:' && url.protocol !== 'https:') {
+    process.stdout.write(JSON.stringify({
+      ok: false,
+      error: 'Only http and https URLs are supported, got ' + url.protocol,
+    }));
+    return;
+  }
+
+  const lib = url.protocol === 'https:' ? https : http;
+  const method = String(opts.method || 'GET').toUpperCase();
+  const headers = Object.assign({}, opts.headers || {});
+  const body = opts.body == null ? '' : String(opts.body);
+  if (body !== '' && headers['Content-Length'] == null && headers['content-length'] == null) {
+    headers['Content-Length'] = Buffer.byteLength(body, 'utf8');
+  }
+
+  const req = lib.request(
+    {
+      protocol: url.protocol,
+      hostname: url.hostname,
+      port: url.port || (url.protocol === 'https:' ? 443 : 80),
+      path: url.pathname + url.search,
+      method,
+      headers,
+      timeout: opts.timeoutMs || ${DEFAULT_TIMEOUT_MS},
+    },
+    (res) => {
+      const chunks = [];
+      let total = 0;
+      res.on('data', (c) => {
+        total += c.length;
+        if (total > ${MAX_BODY_BYTES}) {
+          req.destroy();
+          process.stdout.write(JSON.stringify({
+            ok: false,
+            error: 'Response body exceeds maximum size',
+          }));
+          return;
+        }
+        chunks.push(c);
+      });
+      res.on('end', () => {
+        const respBody = Buffer.concat(chunks).toString('utf8');
+        const respHeaders = {};
+        for (const [k, v] of Object.entries(res.headers)) {
+          if (v == null) continue;
+          respHeaders[k] = Array.isArray(v) ? v.join(', ') : String(v);
+        }
+        process.stdout.write(JSON.stringify({
+          ok: true,
+          status: res.statusCode || 0,
+          body: respBody,
+          headers: respHeaders,
+        }));
+      });
+    },
+  );
+
+  req.on('timeout', () => {
+    req.destroy();
+    process.stdout.write(JSON.stringify({ ok: false, error: 'Request timed out' }));
+  });
+  req.on('error', (e) => {
+    process.stdout.write(JSON.stringify({
+      ok: false,
+      error: e && e.message ? e.message : String(e),
+    }));
+  });
+
+  if (body !== '') req.write(body, 'utf8');
+  req.end();
+});
+`;
+
+  const result = spawnSync(process.execPath, ['-e', script], {
+    input: payload,
+    encoding: 'utf-8',
+    maxBuffer: MAX_BODY_BYTES + 1024 * 1024,
+    timeout: timeoutMs + 5_000,
+  });
+
+  if (result.error) {
+    return { ok: false, error: result.error.message };
+  }
+
+  const stdout = (result.stdout ?? '').trim();
+  if (!stdout) {
+    const stderr = (result.stderr ?? '').trim();
+    return {
+      ok: false,
+      error:
+        stderr ||
+        (result.status != null
+          ? `Request process exited with code ${result.status}`
+          : 'Empty response from HTTP helper'),
+    };
+  }
+
+  try {
+    const parsed = JSON.parse(stdout) as HttpRequestResult;
+    if (parsed && typeof parsed === 'object' && 'ok' in parsed) {
+      return parsed;
+    }
+    return { ok: false, error: 'Malformed response from HTTP helper' };
+  } catch {
+    return {
+      ok: false,
+      error:
+        (result.stderr ?? '').trim() || 'Failed to parse HTTP helper output',
+    };
+  }
+}
+
+/**
+ * Kin object literals only allow identifier keys, so hyphenated HTTP header
+ * names are written with underscores (Content_Type -> Content-Type).
+ */
+function headerNameFromKey(key: string): string {
+  return key.replace(/_/g, '-');
+}
+
+function headersFromObject(value: RuntimeVal): Record<string, string> {
+  if (value.type !== 'object') {
+    throw createKinError('K018', {
+      params: {
+        name: 'KIN_URUBUGA.saba',
+        arg: 4,
+        expected: 'object',
+        got: value.type,
+      },
+      message: `KIN_URUBUGA.saba expects argument 4 to be object, got ${value.type}`,
+    });
+  }
+  const headers: Record<string, string> = {};
+  for (const [key, val] of (value as ObjectVal).properties) {
+    if (val.type !== 'string') {
+      throw createKinError('K018', {
+        params: {
+          name: 'KIN_URUBUGA.saba',
+          arg: 4,
+          expected: 'string header values',
+          got: val.type,
+        },
+        message: `KIN_URUBUGA.saba expects header values to be strings, got ${val.type} for "${key}"`,
+      });
+    }
+    headers[headerNameFromKey(key)] = (val as StringVal).value;
+  }
+  return headers;
+}
+
+function responseObject(result: {
+  status: number;
+  body: string;
+  headers: Record<string, string>;
+}): ObjectVal {
+  const imitwe = new Map<string, RuntimeVal>();
+  for (const [key, value] of Object.entries(result.headers)) {
+    imitwe.set(key, MK_STRING(value));
+  }
+  return MK_OBJECT(
+    new Map<string, RuntimeVal>()
+      .set('kode', MK_NUMBER(result.status))
+      .set('umubiri', MK_STRING(result.body))
+      .set('imitwe', MK_OBJECT(imitwe)),
+  );
+}
+
+/**
+ * KIN_URUBUGA — networking (urubuga = network / web).
+ *
+ * saba(url [, method [, body [, headers]]])
+ *   - Default method is GET when only url is given.
+ *   - Success: object { kode, umubiri, imitwe }
+ *   - Failure (DNS, timeout, bad URL, …): error message string
+ */
+export function createKinUrubuga(): ObjectVal {
+  return MK_OBJECT(
+    new Map().set(
+      'saba',
+      defineNative({
+        name: 'KIN_URUBUGA.saba',
+        params: ['string'],
+        minArgs: 1,
+        maxArgs: 4,
+        fn: (args) => {
+          const url = (args[0] as StringVal).value;
+          let method = 'GET';
+          let body = '';
+          let headers: Record<string, string> = {};
+
+          if (args.length >= 2) {
+            if (args[1].type !== 'string') {
+              throw createKinError('K018', {
+                params: {
+                  name: 'KIN_URUBUGA.saba',
+                  arg: 2,
+                  expected: 'string',
+                  got: args[1].type,
+                },
+                message: `KIN_URUBUGA.saba expects argument 2 to be string, got ${args[1].type}`,
+              });
+            }
+            method = (args[1] as StringVal).value.trim().toUpperCase() || 'GET';
+          }
+
+          if (args.length >= 3) {
+            if (args[2].type !== 'string') {
+              throw createKinError('K018', {
+                params: {
+                  name: 'KIN_URUBUGA.saba',
+                  arg: 3,
+                  expected: 'string',
+                  got: args[2].type,
+                },
+                message: `KIN_URUBUGA.saba expects argument 3 to be string, got ${args[2].type}`,
+              });
+            }
+            body = (args[2] as StringVal).value;
+          }
+
+          if (args.length >= 4) {
+            headers = headersFromObject(args[3]);
+          }
+
+          const result = httpRequestSync({ method, url, body, headers });
+          if (!result.ok) {
+            return MK_STRING(result.error);
+          }
+          return responseObject(result);
+        },
+      }),
+    ),
+  );
+}

--- a/src/runtime/in-built/network.ts
+++ b/src/runtime/in-built/network.ts
@@ -141,8 +141,9 @@ process.stdin.on('end', () => {
           total += c.length;
           if (total > maxBody) {
             oversized = true;
-            req.destroy();
+            // Respond first so a destroy-triggered 'error' cannot win the race.
             fail('Response body exceeds maximum size');
+            req.destroy();
             return;
           }
           chunks.push(c);
@@ -168,8 +169,9 @@ process.stdin.on('end', () => {
     );
 
     req.on('timeout', () => {
-      req.destroy();
+      // Respond first so a destroy-triggered 'error' cannot win the race.
       fail('Request timed out');
+      req.destroy();
     });
     req.on('error', (e) => {
       // After destroy() Node often emits socket hang up — respond() ignores duplicates.

--- a/tests/globals.test.ts
+++ b/tests/globals.test.ts
@@ -725,6 +725,7 @@ describe('createGlobalEnv', () => {
         'KIN_URUTONDE',
         'ubwoko',
         'KIN_INYANDIKO',
+        'KIN_URUBUGA',
       ];
 
       for (const name of expected) {
@@ -732,7 +733,7 @@ describe('createGlobalEnv', () => {
       }
     });
 
-    test('math / string / time / list / file objects expose their methods', () => {
+    test('math / string / time / list / file / network objects expose their methods', () => {
       const env = createGlobalEnv('test.kin');
       const methods: Record<string, string[]> = {
         KIN_IMIBARE: [
@@ -764,6 +765,7 @@ describe('createGlobalEnv', () => {
           'siba_ahabanza',
         ],
         KIN_INYANDIKO: ['soma', 'andika', 'vugurura', 'siba'],
+        KIN_URUBUGA: ['saba'],
       };
 
       for (const [objectName, keys] of Object.entries(methods)) {

--- a/tests/networking.test.ts
+++ b/tests/networking.test.ts
@@ -1,0 +1,278 @@
+import { spawn, ChildProcessWithoutNullStreams } from 'child_process';
+import { afterAll, beforeAll, describe, expect, test } from 'vitest';
+import {
+  asNumber,
+  asObject,
+  asString,
+  evaluate,
+  objectMethod,
+} from './helpers';
+import { createGlobalEnv } from '../src/runtime/globals';
+import {
+  MK_NUMBER,
+  MK_OBJECT,
+  MK_STRING,
+  ObjectVal,
+} from '../src/runtime/values';
+import { httpRequestSync } from '../src/runtime/in-built/network';
+
+/**
+ * Run the HTTP fixture in a *separate* OS process. KIN_URUBUGA.saba uses
+ * spawnSync, which blocks the parent event loop — an in-process server would
+ * never accept connections (classic deadlock).
+ */
+function startTestServerProcess(): Promise<{
+  baseUrl: string;
+  stop: () => void;
+}> {
+  const script = `
+const http = require('http');
+const server = http.createServer((req, res) => {
+  const url = new URL(req.url || '/', 'http://127.0.0.1');
+  const chunks = [];
+  req.on('data', (c) => chunks.push(c));
+  req.on('end', () => {
+    const body = Buffer.concat(chunks).toString('utf8');
+    if (url.pathname === '/echo') {
+      res.writeHead(200, {
+        'Content-Type': 'application/json',
+        'X-Kin-Test': 'echo',
+      });
+      res.end(JSON.stringify({
+        method: req.method,
+        path: url.pathname,
+        query: url.search,
+        body,
+        contentType: req.headers['content-type'] || null,
+      }));
+      return;
+    }
+    if (url.pathname === '/status') {
+      const code = Number(url.searchParams.get('code') || '200');
+      res.writeHead(code, { 'Content-Type': 'text/plain' });
+      res.end('status-' + code);
+      return;
+    }
+    if (url.pathname === '/hello') {
+      res.writeHead(200, { 'Content-Type': 'text/plain; charset=utf-8' });
+      res.end('muraho');
+      return;
+    }
+    res.writeHead(404, { 'Content-Type': 'text/plain' });
+    res.end('not found');
+  });
+});
+server.listen(0, '127.0.0.1', () => {
+  const port = server.address().port;
+  process.stdout.write('READY ' + port + '\\n');
+});
+`;
+
+  return new Promise((resolve, reject) => {
+    const child: ChildProcessWithoutNullStreams = spawn(
+      process.execPath,
+      ['-e', script],
+      { stdio: ['ignore', 'pipe', 'pipe'] },
+    );
+
+    let settled = false;
+    const timer = setTimeout(() => {
+      if (!settled) {
+        settled = true;
+        child.kill('SIGKILL');
+        reject(new Error('Test HTTP server failed to start'));
+      }
+    }, 10_000);
+
+    let buffer = '';
+    child.stdout.on('data', (chunk: Buffer) => {
+      buffer += chunk.toString('utf8');
+      const match = buffer.match(/READY (\d+)/);
+      if (match && !settled) {
+        settled = true;
+        clearTimeout(timer);
+        resolve({
+          baseUrl: `http://127.0.0.1:${match[1]}`,
+          stop: () => {
+            child.kill('SIGTERM');
+          },
+        });
+      }
+    });
+
+    child.stderr.on('data', (chunk: Buffer) => {
+      if (!settled) {
+        // Keep stderr available for debugging failed starts.
+        buffer += chunk.toString('utf8');
+      }
+    });
+
+    child.on('error', (err) => {
+      if (!settled) {
+        settled = true;
+        clearTimeout(timer);
+        reject(err);
+      }
+    });
+
+    child.on('exit', (code) => {
+      if (!settled) {
+        settled = true;
+        clearTimeout(timer);
+        reject(new Error(`Test HTTP server exited early with code ${code}`));
+      }
+    });
+  });
+}
+
+describe('KIN_URUBUGA', () => {
+  let baseUrl: string;
+  let stopServer: () => void;
+
+  beforeAll(async () => {
+    const server = await startTestServerProcess();
+    baseUrl = server.baseUrl;
+    stopServer = server.stop;
+  });
+
+  afterAll(() => {
+    stopServer();
+  });
+
+  test('saba GET returns kode, umubiri, and imitwe', () => {
+    const { result } = evaluate(`KIN_URUBUGA.saba("${baseUrl}/hello")`);
+    const res = asObject(result);
+    expect(asNumber(res.properties.get('kode')!)).toBe(200);
+    expect(asString(res.properties.get('umubiri')!)).toBe('muraho');
+    const headers = asObject(res.properties.get('imitwe')!);
+    const contentType = headers.properties.get('content-type');
+    expect(contentType).toBeDefined();
+    expect(asString(contentType!).toLowerCase()).toContain('text/plain');
+  });
+
+  test('saba default method is GET', () => {
+    const { result } = evaluate(`KIN_URUBUGA.saba("${baseUrl}/echo")`);
+    const body = asString(asObject(result).properties.get('umubiri')!);
+    const parsed = JSON.parse(body) as { method: string };
+    expect(parsed.method).toBe('GET');
+  });
+
+  test('saba POST sends body and method', () => {
+    const { result } = evaluate(
+      `KIN_URUBUGA.saba("${baseUrl}/echo", "POST", "amakuru")`,
+    );
+    const res = asObject(result);
+    expect(asNumber(res.properties.get('kode')!)).toBe(200);
+    const parsed = JSON.parse(asString(res.properties.get('umubiri')!)) as {
+      method: string;
+      body: string;
+    };
+    expect(parsed.method).toBe('POST');
+    expect(parsed.body).toBe('amakuru');
+  });
+
+  test('saba accepts custom headers as an object (underscores become hyphens)', () => {
+    // Kin object keys are identifiers, so Content_Type maps to Content-Type.
+    const { result } = evaluate(`
+      KIN_URUBUGA.saba(
+        "${baseUrl}/echo",
+        "POST",
+        "payload",
+        { Content_Type: "application/json", X_Custom: "kin" }
+      )
+    `);
+    const res = asObject(result);
+    const parsed = JSON.parse(asString(res.properties.get('umubiri')!)) as {
+      contentType: string | null;
+      body: string;
+    };
+    expect(parsed.contentType).toBe('application/json');
+    expect(parsed.body).toBe('payload');
+  });
+
+  test('saba surfaces non-2xx status codes without treating them as errors', () => {
+    const { result } = evaluate(
+      `KIN_URUBUGA.saba("${baseUrl}/status?code=404")`,
+    );
+    const res = asObject(result);
+    expect(asNumber(res.properties.get('kode')!)).toBe(404);
+    expect(asString(res.properties.get('umubiri')!)).toBe('status-404');
+  });
+
+  test('saba returns an error string for an invalid URL scheme', () => {
+    const { result } = evaluate('KIN_URUBUGA.saba("ftp://example.com")');
+    expect(result.type).toBe('string');
+    expect(asString(result).toLowerCase()).toMatch(/http|https|url|protocol/);
+  });
+
+  test('saba returns an error string for a malformed URL', () => {
+    const { result } = evaluate('KIN_URUBUGA.saba("not a url")');
+    expect(result.type).toBe('string');
+    expect(asString(result).length).toBeGreaterThan(0);
+  });
+
+  test('saba validates arity and argument types', () => {
+    expect(() => evaluate('KIN_URUBUGA.saba()')).toThrow(
+      /KIN_URUBUGA.saba expects at least/,
+    );
+    expect(() => evaluate('KIN_URUBUGA.saba(1)')).toThrow(
+      /KIN_URUBUGA.saba expects argument/,
+    );
+    expect(() => evaluate(`KIN_URUBUGA.saba("${baseUrl}/hello", 1)`)).toThrow(
+      /KIN_URUBUGA.saba expects argument 2/,
+    );
+    expect(() =>
+      evaluate(`KIN_URUBUGA.saba("${baseUrl}/hello", "GET", 1)`),
+    ).toThrow(/KIN_URUBUGA.saba expects argument 3/);
+    expect(() =>
+      evaluate(`KIN_URUBUGA.saba("${baseUrl}/hello", "GET", "", "not-object")`),
+    ).toThrow(/KIN_URUBUGA.saba expects argument 4/);
+  });
+
+  test('saba rejects non-string header values', () => {
+    const env = createGlobalEnv('test.kin');
+    const saba = objectMethod(env, 'KIN_URUBUGA', 'saba');
+    const headers = MK_OBJECT(new Map().set('X-Num', MK_NUMBER(1)));
+    expect(() =>
+      saba.call(
+        [
+          MK_STRING(`${baseUrl}/hello`),
+          MK_STRING('GET'),
+          MK_STRING(''),
+          headers,
+        ],
+        env,
+      ),
+    ).toThrow(/header values/);
+  });
+
+  test('response fields are readable from Kin with member access', () => {
+    const { result } = evaluate(`
+      reka res = KIN_URUBUGA.saba("${baseUrl}/hello")
+      res.umubiri
+    `);
+    expect(asString(result)).toBe('muraho');
+  });
+
+  test('httpRequestSync helper returns structured success payloads', () => {
+    const result = httpRequestSync({
+      method: 'GET',
+      url: `${baseUrl}/hello`,
+    });
+    expect(result).toEqual({
+      ok: true,
+      status: 200,
+      body: 'muraho',
+      headers: expect.objectContaining({
+        'content-type': expect.stringContaining('text/plain'),
+      }),
+    });
+  });
+
+  test('environment exposes KIN_URUBUGA.saba', () => {
+    const env = createGlobalEnv('test.kin');
+    const obj = env.lookupVar('KIN_URUBUGA') as ObjectVal;
+    expect(obj.type).toBe('object');
+    expect(obj.properties.get('saba')?.type).toBe('native-fn');
+  });
+});

--- a/tests/networking.test.ts
+++ b/tests/networking.test.ts
@@ -58,6 +58,24 @@ const server = http.createServer((req, res) => {
       res.end('muraho');
       return;
     }
+    if (url.pathname === '/hang') {
+      // Never respond — exercises request timeout.
+      return;
+    }
+    if (url.pathname === '/big') {
+      const size = Number(url.searchParams.get('n') || '100');
+      res.writeHead(200, { 'Content-Type': 'application/octet-stream' });
+      res.end(Buffer.alloc(size, 0x61));
+      return;
+    }
+    if (url.pathname === '/redir') {
+      res.writeHead(302, {
+        Location: '/hello',
+        'Content-Type': 'text/plain',
+      });
+      res.end('moved');
+      return;
+    }
     res.writeHead(404, { 'Content-Type': 'text/plain' });
     res.end('not found');
   });
@@ -102,7 +120,6 @@ server.listen(0, '127.0.0.1', () => {
 
     child.stderr.on('data', (chunk: Buffer) => {
       if (!settled) {
-        // Keep stderr available for debugging failed starts.
         buffer += chunk.toString('utf8');
       }
     });
@@ -145,7 +162,8 @@ describe('KIN_URUBUGA', () => {
     expect(asNumber(res.properties.get('kode')!)).toBe(200);
     expect(asString(res.properties.get('umubiri')!)).toBe('muraho');
     const headers = asObject(res.properties.get('imitwe')!);
-    const contentType = headers.properties.get('content-type');
+    // Response header keys use underscores for Kin identifier access.
+    const contentType = headers.properties.get('content_type');
     expect(contentType).toBeDefined();
     expect(asString(contentType!).toLowerCase()).toContain('text/plain');
   });
@@ -172,7 +190,6 @@ describe('KIN_URUBUGA', () => {
   });
 
   test('saba accepts custom headers as an object (underscores become hyphens)', () => {
-    // Kin object keys are identifiers, so Content_Type maps to Content-Type.
     const { result } = evaluate(`
       KIN_URUBUGA.saba(
         "${baseUrl}/echo",
@@ -190,6 +207,14 @@ describe('KIN_URUBUGA', () => {
     expect(parsed.body).toBe('payload');
   });
 
+  test('response headers are readable from Kin via underscore keys', () => {
+    const { result } = evaluate(`
+      reka res = KIN_URUBUGA.saba("${baseUrl}/hello")
+      res.imitwe.content_type
+    `);
+    expect(asString(result).toLowerCase()).toContain('text/plain');
+  });
+
   test('saba surfaces non-2xx status codes without treating them as errors', () => {
     const { result } = evaluate(
       `KIN_URUBUGA.saba("${baseUrl}/status?code=404")`,
@@ -197,6 +222,15 @@ describe('KIN_URUBUGA', () => {
     const res = asObject(result);
     expect(asNumber(res.properties.get('kode')!)).toBe(404);
     expect(asString(res.properties.get('umubiri')!)).toBe('status-404');
+  });
+
+  test('saba does not follow redirects', () => {
+    const { result } = evaluate(`KIN_URUBUGA.saba("${baseUrl}/redir")`);
+    const res = asObject(result);
+    expect(asNumber(res.properties.get('kode')!)).toBe(302);
+    expect(asString(res.properties.get('umubiri')!)).toBe('moved');
+    const headers = asObject(res.properties.get('imitwe')!);
+    expect(asString(headers.properties.get('location')!)).toBe('/hello');
   });
 
   test('saba returns an error string for an invalid URL scheme', () => {
@@ -209,6 +243,47 @@ describe('KIN_URUBUGA', () => {
     const { result } = evaluate('KIN_URUBUGA.saba("not a url")');
     expect(result.type).toBe('string');
     expect(asString(result).length).toBeGreaterThan(0);
+  });
+
+  test('saba returns a connection error string for ECONNREFUSED', () => {
+    // Port 1 is almost never open on localhost.
+    const { result } = evaluate('KIN_URUBUGA.saba("http://127.0.0.1:1/")');
+    expect(result.type).toBe('string');
+    expect(asString(result).toLowerCase()).toMatch(
+      /econnrefused|connect|refused/,
+    );
+  });
+
+  test('httpRequestSync reports Request timed out on hang (not parse failure)', () => {
+    const result = httpRequestSync({
+      method: 'GET',
+      url: `${baseUrl}/hang`,
+      timeoutMs: 400,
+    });
+    expect(result).toEqual({ ok: false, error: 'Request timed out' });
+  }, 15_000);
+
+  test('saba surfaces timeout as a plain error string', () => {
+    // Timeout is not configurable from Kin source; assert the helper message
+    // that saba returns as a string on failure.
+    const result = httpRequestSync({
+      method: 'GET',
+      url: `${baseUrl}/hang`,
+      timeoutMs: 300,
+    });
+    expect(result).toEqual({ ok: false, error: 'Request timed out' });
+  }, 15_000);
+
+  test('httpRequestSync reports oversize body cleanly', () => {
+    const result = httpRequestSync({
+      method: 'GET',
+      url: `${baseUrl}/big?n=64`,
+      maxBodyBytes: 16,
+    });
+    expect(result).toEqual({
+      ok: false,
+      error: 'Response body exceeds maximum size',
+    });
   });
 
   test('saba validates arity and argument types', () => {
@@ -264,7 +339,7 @@ describe('KIN_URUBUGA', () => {
       status: 200,
       body: 'muraho',
       headers: expect.objectContaining({
-        'content-type': expect.stringContaining('text/plain'),
+        content_type: expect.stringContaining('text/plain'),
       }),
     });
   });

--- a/tests/networking.test.ts
+++ b/tests/networking.test.ts
@@ -263,9 +263,9 @@ describe('KIN_URUBUGA', () => {
     expect(result).toEqual({ ok: false, error: 'Request timed out' });
   }, 15_000);
 
-  test('saba surfaces timeout as a plain error string', () => {
-    // Timeout is not configurable from Kin source; assert the helper message
-    // that saba returns as a string on failure.
+  test('timeout helper path returns the stable error string saba surfaces', () => {
+    // Kin source cannot pass timeoutMs; saba uses the same httpRequestSync path
+    // with a 30s default. Assert the stable message that path returns on hang.
     const result = httpRequestSync({
       method: 'GET',
       url: `${baseUrl}/hang`,


### PR DESCRIPTION
## Summary

Implements a **first slice of native networking** for Kin (HTTP client only) for https://github.com/kin-lang/kin/issues/255.

> **Does not fully close #255** — TCP/UDP sockets remain out of scope for this PR.

### `KIN_URUBUGA.saba` — synchronous HTTP client

| Call | Behavior |
| --- | --- |
| `saba(url)` | GET |
| `saba(url, method)` | custom method (`GET` / `POST` / …) |
| `saba(url, method, body)` | request with UTF-8 body string |
| `saba(url, method, body, headers)` | plus headers object |

**Success** returns an object:

- `kode` — HTTP status number (including non-2xx and redirects)
- `umubiri` — response body as **UTF-8 text**
- `imitwe` — response headers (string values; keys use **underscores**, e.g. `content_type`)

**Transport failure** (bad URL, 30s timeout → `"Request timed out"`, DNS, ECONNREFUSED, oversized body, …) returns an **error message string**, matching `KIN_INYANDIKO`.

**Redirects are not followed** — a `302` is returned as-is; check `res.imitwe.location`.

Request header object keys are Kin identifiers; underscores map to hyphens (`Content_Type` → `Content-Type`).

Implementation: `src/runtime/in-built/network.ts` — short-lived Node child with a **one-shot** JSON response so timeout+error cannot concatenate payloads.

### Also included

- `examples/networking.kin`
- Unit tests (separate-process fixture): success, POST, headers, 404, redirect, invalid scheme/URL, ECONNREFUSED, hang timeout, oversize body, Kin header member access
- Registration on the global env + env-shape coverage in `tests/globals.test.ts`

### Review fixes (cycle 1)

- Fixed timeout double-write → stable `"Request timed out"`
- Fixed oversize body hang → `"Response body exceeds maximum size"`
- Response headers usable as `res.imitwe.content_type`
- Documented redirects, UTF-8 bodies, 30s timeout
- PR no longer auto-closes full issue #255
- Sibling monorepo branches rebased clean onto their mains

### Out of scope (follow-ups)

- TCP/UDP sockets
- Automatic redirect following
- Streaming / chunked helpers
- Async / non-blocking API

## Test plan

- [x] `npx vitest --no-watch` — **241 passed** (18 networking tests)
- [x] Timeout hang path asserts exact `"Request timed out"`
- [x] Oversize path asserts exact oversize message
- [x] `examples/networking.kin` runs under examples suite
- [x] Lint clean on new files

## Monorepo follow-ups

| Package | PR / branch | Notes |
| --- | --- | --- |
| [vscode-intellisense](https://github.com/kin-lang/vscode-intellisense/pull/12) | `herdr/issue-255-networking` | Clean 1-commit branch on main |
| [wiki](https://github.com/kin-lang/wiki/pull/26) | `herdr/issue-255-networking` | Clean 1-commit branch on main |
| [editor](https://github.com/kin-lang/editor/pull/7) | `herdr/issue-255-networking` | Playground stubs `saba` as security-disabled |

Related: #255 (HTTP first slice only).