### PR TITLE
feat: runtime type system with Kinyarwanda type names

### DIFF
--- a/README.md
+++ b/README.md
@@ -94,11 +94,11 @@ npm run build:exe:all
 - This is implementation of linear search:
 
   ```Kin
-  reka arr = [45, 56, 334, 78, 34, 78, 23, 90]
+  reka arr: urutonde = [45, 56, 334, 78, 34, 78, 23, 90]
 
-  reka i = 0
+  reka i: umubare = 0
 
-  reka key = 23
+  reka key: umubare = 23
 
   subiramo_niba(i < KIN_URUTONDE.ingano(arr)) {
     niba (arr[i] == key) {
@@ -111,8 +111,19 @@ npm run build:exe:all
 
 - Hello \<name\> !
   ```Kin
-  reka name = injiza_amakuru("Enter your name: ")
+  reka name: ijambo = injiza_amakuru("Enter your name: ")
   tangaza_amakuru("Hello ", name, "!")
+  ```
+- Typed functions and type aliases
+  ```Kin
+  ubwoko Person = { name: ijambo, age: umubare }
+
+  porogaramu_ntoya greet(p: Person): ijambo {
+    tanga "Muraho " + p.name
+  }
+
+  reka keza: Person = { name: "Keza", age: 20 }
+  tangaza_amakuru(greet(keza))
   ```
 - Executing system commands
   ```Kin

--- a/docs/errors.md
+++ b/docs/errors.md
@@ -49,5 +49,10 @@ Host programs can branch on `instanceof`, `ERRNAME`, or `ERRCODE`.
 | K029 | RuntimeError | Unhandled type in equality | internal | Report to Kin developers. |
 | K030 | SyntaxError | Expected function name following porogaramu_ntoya | `porogaramu_ntoya (){}` | Name the function. |
 | K031 | SyntaxError | Variable name expected following reka or ntahinduka | `reka = 1` | Write `reka name = ...`. |
+| K032 | SyntaxError | Expected a type, found {lexeme} | `reka x: = 1` | Write a type name or object type after `:`. |
+| K033 | TypeError | Unknown type '{name}' | `reka x: Foo = 1` | Declare the type with `ubwoko Foo = ...` first. |
+| K034 | TypeError | Invalid Fata type | `Fata<umubare, "a">` | Fata only works on object types with existing keys. |
+| K035 | TypeError | Cannot assign a {got} to a {expected} | `reka x: ijambo = 1` | Assign a value that matches the annotation. |
+| K036 | TypeError | Type '{name}' is already defined | two `ubwoko Person = ...` | Use a unique type name. |
 
 Messages are loaded from `src/messages/rw.json` (default) and `src/messages/en.json` (`KIN_LANG=en`).

--- a/examples/arrays.kin
+++ b/examples/arrays.kin
@@ -1,14 +1,14 @@
-reka list = [1+4] # Array can contain expressions
+reka list: urutonde = [1+4] # Array can contain expressions
 tangaza_amakuru(list[0]) # will print 5
 
-reka list2 = [KIN_IGIHE.isaha] # Array can contain function's identifier
+reka list2: urutonde = [KIN_IGIHE.isaha] # Array can contain function's identifier
 tangaza_amakuru(list2[0]()) # will print current time in this format HH:MM:SS
 
-reka list3 = [{key: "value"}] # Array can contain object
+reka list3: urutonde = [{key: "value"}] # Array can contain object
 tangaza_amakuru(list3[0].key) # this will print value
 
-reka list4 = [[1, 2], [3, 4]] # Arrays can be nested
+reka list4: urutonde = [[1, 2], [3, 4]] # Arrays can be nested
 tangaza_amakuru(list4[1][0]) # This will print 3
 
-reka list5 = [list, list2] # Array can contain variable names
+reka list5: urutonde = [list, list2] # Array can contain variable names
 tangaza_amakuru(list5[1][0]()) # this will print time on screen since it's at index 0 of list2 array

--- a/examples/conditional-statement.kin
+++ b/examples/conditional-statement.kin
@@ -1,4 +1,4 @@
-reka grade = 90
+reka grade: umubare = 90
 
 niba (grade >= 90) {
   tangaza_amakuru("Excellent work! You got an A.")

--- a/examples/functions.kin
+++ b/examples/functions.kin
@@ -5,15 +5,15 @@ porogaramu_ntoya printTime() {
 
 printTime() # This will print current time in this format: HH:MM:SS
 
-# function that return something
-porogaramu_ntoya add(a, b) {
+# function with typed parameters and return type
+porogaramu_ntoya add(a: umubare, b: umubare): umubare {
     tanga a + b
 }
 
 tangaza_amakuru(add(1, 2)) # This will print 3
 
 # function being a member of an object
-reka obj = {
+reka obj: ubwoko_imiterere = {
     addNumbers: add
 }
 

--- a/examples/io.kin
+++ b/examples/io.kin
@@ -1,4 +1,4 @@
-reka input = injiza_amakuru("Write something : ") # Input
+reka input: ijambo = injiza_amakuru("Write something : ") # Input
 tangaza_amakuru(input) # Output
 
 # This will also work

--- a/examples/loops.kin
+++ b/examples/loops.kin
@@ -1,4 +1,4 @@
-reka i = 1
+reka i: umubare = 1
 subiramo_niba(i<=100) {
     tangaza_amakuru(i)
     # stop the loop when i reaches 5
@@ -9,7 +9,7 @@ subiramo_niba(i<=100) {
 }
 
 # komeza skips the rest of the current iteration (even numbers here)
-reka n = 0
+reka n: umubare = 0
 subiramo_niba(n < 10) {
     n = n + 1
     niba(n % 2 == 0) {

--- a/examples/objects.kin
+++ b/examples/objects.kin
@@ -1,11 +1,30 @@
-porogaramu_ntoya add (a, b) {
+# Typed function used as an object property
+porogaramu_ntoya add(a: umubare, b: umubare): umubare {
     tanga a + b
 }
 
-# object can't as complex as you want in Kin
+# Named object types with nesting (type chaining)
+ubwoko SubObj = {
+    sub_sub_key: ijambo
+}
+
+ubwoko Key4 = {
+    sub_key: ijambo,
+    sub_obj: SubObj
+}
+
+ubwoko Bag = {
+    key: ijambo,
+    key2: umubare,
+    key3: porogaramu_ntoya,
+    key4: Key4,
+    key5: urutonde
+}
+
+# object can be as complex as you want in Kin
 # only make sure that key is a string and value is an expression.
 
-reka obj = {
+reka obj: Bag = {
     key: "value",
     key2: 1,
     key3: add,

--- a/examples/switch.kin
+++ b/examples/switch.kin
@@ -1,9 +1,9 @@
-reka iletere = injiza_amakuru("shyiramo letere nyamuneka:")
+reka iletere: ijambo = injiza_amakuru("shyiramo letere nyamuneka:")
 
 gereranya(iletere){
     usanze "a":
-       reka a = 1
-       reka b = 2
+       reka a: umubare = 1
+       reka b: umubare = 2
        tangaza_amakuru(a+b)
        tangaza_amakuru("Iyi letere ni a")
     usanze "b":

--- a/examples/types.kin
+++ b/examples/types.kin
@@ -1,0 +1,69 @@
+# =============================================================================
+# Ubwoko (type safety) muri Kin
+# =============================================================================
+# Ubwoko butokenizwa, buparswa, kandi bugenzurwa igihe porogaramu ikora.
+# Bishyirwa ku minduragaciro, ku bipimo by'umumaro, no ku gaciro gasubizwa.
+# `ubwoko` rirema amazina y'ubwoko; kandi `ubwoko(x)` isubiza ubwoko bw'agaciro.
+# =============================================================================
+
+# --- Amazina yubatsemo -------------------------------------------------------
+reka age: umubare = 25
+reka name: ijambo = "Keza"
+reka ok: ukuri = nibyo
+reka items: urutonde = [1, 2, 3]
+reka maybe: umubare? = ubusa
+
+# --- Union -------------------------------------------------------------------
+ubwoko Id = ijambo | umubare
+reka id1: Id = "A-1"
+reka id2: Id = 42
+
+# --- Ikintu + ubwoko bujya mu bindi ------------------------------------------
+ubwoko Address = {
+    city: ijambo,
+    street: ijambo
+}
+
+ubwoko Person = {
+    name: ijambo,
+    age: umubare,
+    address: Address
+}
+
+reka keza: Person = {
+    name: "Keza",
+    age: 20,
+    address: {
+        city: "Kigali",
+        street: "KG 1 Ave"
+    }
+}
+
+# --- Fata (gufata imfunguzo zihariye) -----------------------------------------
+ubwoko PersonName = Fata<Person, "name">
+ubwoko PersonNameAge = Fata<Person, "name" | "age">
+
+reka onlyName: PersonName = { name: "Keza" }
+reka nameAndAge: PersonNameAge = { name: "Keza", age: 20 }
+
+# --- Imimaro ifite ubwoko ----------------------------------------------------
+porogaramu_ntoya fullName(first: ijambo, last: ijambo): ijambo {
+    tanga first + " " + last
+}
+
+porogaramu_ntoya birthday(p: Person): umubare {
+    tanga p.age + 1
+}
+
+tangaza_amakuru(fullName("Keza", "Uwase"))
+tangaza_amakuru(birthday(keza))
+tangaza_amakuru(keza.address.city)
+tangaza_amakuru(onlyName.name)
+tangaza_amakuru(id1)
+tangaza_amakuru(id2)
+tangaza_amakuru(ubwoko(age))
+tangaza_amakuru(ubwoko(name))
+
+# Fungura kureba ikosa ry'ubwoko:
+# reka bad: ijambo = 123
+#   -> Cannot assign a umubare to a ijambo, expected a ijambo instead.

--- a/grammar.bnf
+++ b/grammar.bnf
@@ -25,6 +25,7 @@ program ::= statement*
 ; ========================================
 
 statement ::= variableDeclaration
+            | typeAliasDeclaration
             | functionDeclaration
             | loopStatement
             | breakStatement
@@ -37,12 +38,42 @@ statement ::= variableDeclaration
 ; Semicolon is required only when the initializer is omitted.
 ; Constants (ntahinduka) must have an initializer — the parser rejects
 ; "ntahinduka name ;".
-variableDeclaration ::= "reka" identifier (";" | "=" expression)
-                      | "ntahinduka" identifier "=" expression
+; Optional type annotations are kept on the AST and checked at runtime.
+variableDeclaration ::= "reka" identifier typeAnnotation? (";" | "=" expression)
+                      | "ntahinduka" identifier typeAnnotation? "=" expression
 
-functionDeclaration ::= "porogaramu_ntoya" identifier "(" parameterList? ")" block
+; Named type alias (not erased). Supports object types, unions, Fata, nesting.
+; `ubwoko` is also the typeof function in expressions: ubwoko(x).
+typeAliasDeclaration ::= "ubwoko" identifier "=" typeExpression
 
-parameterList ::= identifier ("," identifier)*
+functionDeclaration ::= "porogaramu_ntoya" identifier "(" parameterList? ")"
+                        typeAnnotation? block
+
+parameterList ::= parameter ("," parameter)*
+parameter     ::= identifier typeAnnotation?
+
+; `: type` required; `: type?` also accepts ubusa.
+typeAnnotation ::= ":" typeExpression "?"?
+
+; Union has lowest precedence among type operators.
+typeExpression ::= typePrimary ("|" typePrimary)*
+
+typePrimary ::= typeName
+              | objectType
+              | fataType
+              | "(" typeExpression ")"
+
+; Built-in type names (Kinyarwanda) or user aliases.
+; porogaramu_ntoya is a keyword token that is also a type name.
+typeName ::= "umubare" | "ijambo" | "ukuri" | "ubwoko_imiterere" | "urutonde"
+           | "porogaramu_ntoya" | "_porogaramu_ntoya" | "ubusa"
+           | identifier
+
+objectType ::= "{" (identifier ":" typeExpression
+                    ("," identifier ":" typeExpression)* ","?)? "}"
+
+; Select keys from an object type: Fata<Person, "name" | "age">
+fataType ::= "Fata" "<" typeExpression "," stringLiteral ("|" stringLiteral)* ">"
 
 block ::= "{" statement* "}"
 
@@ -189,6 +220,11 @@ stringLiteral ::= '"' { anyCharacterExceptQuoteOrNewline } '"'
 ; subiramo_niba  hagarara  komeza
 ; niba  nanone_niba  niba_byanze
 ; gereranya  usanze  ibindi
+; ubwoko   (type alias keyword; also typeof function name)
+
+; Built-in type names:
+; umubare  ijambo  ukuri  ubwoko_imiterere  urutonde
+; porogaramu_ntoya  _porogaramu_ntoya  ubusa
 
 ; ========================================
 ; Unused tokens  (lexer only — not in this grammar)
@@ -196,5 +232,6 @@ stringLiteral ::= '"' { anyCharacterExceptQuoteOrNewline } '"'
 ;
 ; ++  --     tokenized (INCREMENT / DECREMENT), never parsed
 ; &          tokenized (AMPERSAND), never parsed  (&& is AND and is used)
-; |          lexer error unless it is part of ||
+; |          tokenized (PIPE); used in type unions and Pick key lists
+; ?          tokenized (QUESTION); used for optional types (number?)
 ; '          not recognized; strings use " only

--- a/src/lexer/lexer.ts
+++ b/src/lexer/lexer.ts
@@ -209,6 +209,8 @@ class Lexer {
         return TokenType.USANZE;
       case 'ibindi':
         return TokenType.IBINDI;
+      case 'ubwoko':
+        return TokenType.UBWOKO;
       default:
         return undefined;
     }
@@ -288,11 +290,11 @@ class Lexer {
           this.advance();
           return this.makeToken(TokenType.OR, '||', start, line, column);
         }
-        throw createKinError('K004', {
-          span: { start, end: this.currentPos, line, column },
-          params: { char: '|' },
-          message: `Unexpected character '|' at line ${line}`,
-        });
+        // Single `|` is a type-level union / Pick key separator.
+        return this.makeToken(TokenType.PIPE, '|', start, line, column);
+      case '?':
+        this.advance();
+        return this.makeToken(TokenType.QUESTION, '?', start, line, column);
       case ';':
         this.advance();
         return this.makeToken(TokenType.SEMI_COLON, ';', start, line, column);

--- a/src/lexer/tokens.ts
+++ b/src/lexer/tokens.ts
@@ -28,6 +28,10 @@ enum TokenType {
   LESS_THAN,
   COMMA,
   EQUAL,
+  /** Single `|` used in type unions (`string | number`) and Pick key lists. */
+  PIPE,
+  /** `?` marks optional types (`number?`). */
+  QUESTION,
 
   /* Literals */
   IDENTIFIER,
@@ -59,6 +63,11 @@ enum TokenType {
   GERERANYA,
   USANZE,
   IBINDI,
+  /**
+   * Type-related keyword: type alias declaration (`ubwoko Person = …`)
+   * and still usable as the typeof function name in expressions (`ubwoko(x)`).
+   */
+  UBWOKO,
   EOF,
 }
 

--- a/src/lib/errors.ts
+++ b/src/lib/errors.ts
@@ -45,13 +45,14 @@ export const CODE_CATEGORY: Readonly<Record<string, KinErrorName>> = {
   K023: 'SyntaxError',
   K030: 'SyntaxError',
   K031: 'SyntaxError',
+  K032: 'SyntaxError',
 
   // Reference — names / bindings
   K005: 'ReferenceError',
   K006: 'ReferenceError',
   K007: 'ReferenceError',
 
-  // Type — values, arity, operators, indexes
+  // Type — values, arity, operators, indexes, annotations
   K008: 'TypeError',
   K009: 'TypeError',
   K010: 'TypeError',
@@ -61,6 +62,10 @@ export const CODE_CATEGORY: Readonly<Record<string, KinErrorName>> = {
   K017: 'TypeError',
   K018: 'TypeError',
   K024: 'TypeError',
+  K033: 'TypeError',
+  K034: 'TypeError',
+  K035: 'TypeError',
+  K036: 'TypeError',
 
   // Runtime — control flow, exit, internals
   K013: 'RuntimeError',

--- a/src/messages/en.json
+++ b/src/messages/en.json
@@ -29,5 +29,10 @@
   "K028": "Unknown operator '{op}'",
   "K029": "Unhandled type in equality: {type}",
   "K030": "Expected function name following porogaramu_ntoya",
-  "K031": "Variable name expected following reka or ntahinduka"
+  "K031": "Variable name expected following reka or ntahinduka",
+  "K032": "Expected a type, found {lexeme}",
+  "K033": "Unknown type '{name}'",
+  "K034": "Invalid Pick type: {message}",
+  "K035": "Cannot assign a {got} to a {expected}, expected a {expected} instead",
+  "K036": "Type '{name}' is already defined"
 }

--- a/src/messages/rw.json
+++ b/src/messages/rw.json
@@ -29,5 +29,10 @@
   "K028": "Ikimenyetso kitazwi '{op}'",
   "K029": "Ubwoko butazwi mu kugereranya: {type}",
   "K030": "Byari biteganyijwe izina rya porogaramu_ntoya",
-  "K031": "Byari biteganyijwe izina ry'ihinduragaciro nyuma ya reka cyangwa ntahinduka"
+  "K031": "Byari biteganyijwe izina ry'ihinduragaciro nyuma ya reka cyangwa ntahinduka",
+  "K032": "Byari biteganyijwe ubwoko, habonetse {lexeme}",
+  "K033": "Ubwoko '{name}' ntabwo buzwi",
+  "K034": "Ubwoko bwa Pick si bwo: {message}",
+  "K035": "Ntushobora guha {got} kuri {expected}, byari biteganyijwe {expected}",
+  "K036": "Ubwoko '{name}' busanzwe buhari"
 }

--- a/src/parser/ast.ts
+++ b/src/parser/ast.ts
@@ -10,6 +10,7 @@ export type NodeType =
   | 'Program'
   | 'VariableDeclaration'
   | 'FunctionDeclaration'
+  | 'TypeAliasDeclaration'
   | 'LoopStatement'
   | 'BreakStatement'
   | 'ContinueStatement'
@@ -29,7 +30,14 @@ export type NodeType =
   | 'NumericLiteral'
   | 'StringLiteral'
   | 'Identifier'
-  | 'Property';
+  | 'Property'
+
+  // Type AST (kept through parse → runtime; not erased)
+  | 'NamedType'
+  | 'ObjectType'
+  | 'UnionType'
+  | 'PickType'
+  | 'TypeAnnotation';
 
 /**
  * Statements do not result in a value at runtime.
@@ -54,6 +62,73 @@ export interface Program extends Stmt {
   body: Stmt[];
 }
 
+// ---------------------------------------------------------------------------
+// Type AST
+// Types are tokenized and parsed into these nodes, then checked at runtime.
+// ---------------------------------------------------------------------------
+
+/** Named type reference: `number`, `string`, `Person`, … */
+export interface NamedType {
+  kind: 'NamedType';
+  name: string;
+  span: Span;
+}
+
+/** One property inside an object type: `name: string` */
+export interface ObjectTypeProperty {
+  key: string;
+  type: TypeNode;
+  span: Span;
+}
+
+/** Object type literal: `{ name: string, age: number }` */
+export interface ObjectType {
+  kind: 'ObjectType';
+  properties: ObjectTypeProperty[];
+  span: Span;
+}
+
+/** Union: `string | number` */
+export interface UnionType {
+  kind: 'UnionType';
+  members: TypeNode[];
+  span: Span;
+}
+
+/**
+ * Select keys from an object type: `Fata<Person, "name" | "age">`
+ * (TypeScript Pick). `target` is the source type; `keys` are kept.
+ */
+export interface PickType {
+  kind: 'PickType';
+  target: TypeNode;
+  keys: string[];
+  span: Span;
+}
+
+/** Any type expression node (before optional `?` wrapping). */
+export type TypeNode = NamedType | ObjectType | UnionType | PickType;
+
+/**
+ * Full annotation as written after `:` — may be optional (`number?`).
+ */
+export interface TypeAnnotation {
+  kind: 'TypeAnnotation';
+  type: TypeNode;
+  /** When true, `ubusa` is also accepted. */
+  optional: boolean;
+  span: Span;
+}
+
+/**
+ * Function parameter with optional type annotation.
+ */
+export interface FunctionParameter {
+  name: string;
+  typeAnnotation?: TypeAnnotation;
+  span: Span;
+}
+
 /**
  * Defines a variable declaration
  */
@@ -61,7 +136,17 @@ export interface VariableDeclaration extends Stmt {
   kind: 'VariableDeclaration';
   constant: boolean;
   identifier: string;
+  typeAnnotation?: TypeAnnotation;
   value?: Expr;
+}
+
+/**
+ * Named type alias: `ubwoko Person = { name: ijambo }`
+ */
+export interface TypeAliasDeclaration extends Stmt {
+  kind: 'TypeAliasDeclaration';
+  name: string;
+  type: TypeNode;
 }
 
 /**
@@ -105,7 +190,8 @@ export interface ContinueStatement extends Stmt {
 export interface FunctionDeclaration extends Stmt {
   kind: 'FunctionDeclaration';
   name: string;
-  parameters: string[];
+  parameters: FunctionParameter[];
+  returnType?: TypeAnnotation;
   body: Stmt[];
 }
 
@@ -207,8 +293,63 @@ export function mkVarDecl(
   constant: boolean,
   value: Expr | undefined,
   span: Span,
+  typeAnnotation?: TypeAnnotation,
 ): VariableDeclaration {
-  return { kind: 'VariableDeclaration', identifier, constant, value, span };
+  return {
+    kind: 'VariableDeclaration',
+    identifier,
+    constant,
+    value,
+    typeAnnotation,
+    span,
+  };
+}
+
+export function mkTypeAlias(
+  name: string,
+  type: TypeNode,
+  span: Span,
+): TypeAliasDeclaration {
+  return { kind: 'TypeAliasDeclaration', name, type, span };
+}
+
+export function mkNamedType(name: string, span: Span): NamedType {
+  return { kind: 'NamedType', name, span };
+}
+
+export function mkObjectType(
+  properties: ObjectTypeProperty[],
+  span: Span,
+): ObjectType {
+  return { kind: 'ObjectType', properties, span };
+}
+
+export function mkUnionType(members: TypeNode[], span: Span): UnionType {
+  return { kind: 'UnionType', members, span };
+}
+
+export function mkPickType(
+  target: TypeNode,
+  keys: string[],
+  span: Span,
+): PickType {
+  return { kind: 'PickType', target, keys, span };
+}
+
+export function mkTypeAnnotation(
+  type: TypeNode,
+  optional: boolean,
+  span: Span,
+): TypeAnnotation {
+  return { kind: 'TypeAnnotation', type, optional, span };
+}
+
+export function mkFunctionParam(
+  name: string,
+  span: Span,
+  typeAnnotation?: TypeAnnotation,
+): FunctionParameter {
+  return { name, typeAnnotation, span };
 }
 
 export function mkConditional(
@@ -244,11 +385,19 @@ export function mkContinue(span: Span): ContinueStatement {
 
 export function mkFunction(
   name: string,
-  parameters: string[],
+  parameters: FunctionParameter[],
   body: Stmt[],
   span: Span,
+  returnType?: TypeAnnotation,
 ): FunctionDeclaration {
-  return { kind: 'FunctionDeclaration', name, parameters, body, span };
+  return {
+    kind: 'FunctionDeclaration',
+    name,
+    parameters,
+    returnType,
+    body,
+    span,
+  };
 }
 
 export function mkReturn(value: Expr | undefined, span: Span): ReturnExpr {

--- a/src/parser/parser.ts
+++ b/src/parser/parser.ts
@@ -9,8 +9,11 @@ import { KinError, createKinError } from '../lib/errors';
 import { Span, emptySpan, mergeSpans } from '../lib/span';
 import {
   Expr,
+  FunctionParameter,
   Program,
   Stmt,
+  TypeAnnotation,
+  TypeNode,
   mkArray,
   mkAssign,
   mkBinary,
@@ -19,18 +22,25 @@ import {
   mkConditional,
   mkContinue,
   mkFunction,
+  mkFunctionParam,
   mkIdent,
   mkLoop,
   mkMember,
+  mkNamedType,
   mkNumber,
   mkObject,
+  mkObjectType,
+  mkPickType,
   mkProgram,
   mkProperty,
   mkReturn,
   mkString,
+  mkTypeAlias,
+  mkTypeAnnotation,
   mkUnary,
+  mkUnionType,
   mkVarDecl,
-  Identifier,
+  ObjectTypeProperty,
 } from './ast';
 
 export interface Diagnostic {
@@ -193,6 +203,7 @@ export default class Parser {
         t === TokenType.POROGARAMU_NTOYA ||
         t === TokenType.GERERANYA ||
         t === TokenType.TANGA ||
+        t === TokenType.UBWOKO ||
         t === TokenType.CLOSE_CURLY_BRACES ||
         t === TokenType.HAGARARA ||
         t === TokenType.KOMEZA
@@ -208,6 +219,15 @@ export default class Parser {
       case TokenType.REKA:
       case TokenType.NTAHINDUKA:
         return this.parse_var_declaration();
+      case TokenType.UBWOKO:
+        // `ubwoko Name = Type` is a type alias. `ubwoko(x)` / bare use is an expression.
+        if (
+          this.peek(1).type === TokenType.IDENTIFIER &&
+          this.peek(2).type === TokenType.EQUAL
+        ) {
+          return this.parse_type_alias_declaration();
+        }
+        return this.parse_expr();
       case TokenType.NIBA:
         return this.parse_if_statement();
       case TokenType.GERERANYA:
@@ -378,6 +398,11 @@ export default class Parser {
     const nameTok = this.expect(TokenType.IDENTIFIER, 'variable name');
     const identifier = nameTok.lexeme;
 
+    const typeAnnotation =
+      this.at().type == TokenType.COLON
+        ? this.parse_type_annotation()
+        : undefined;
+
     if (this.at().type == TokenType.SEMI_COLON) {
       const semi = this.eat();
       if (isConstant) {
@@ -393,16 +418,163 @@ export default class Parser {
         false,
         undefined,
         mergeSpans(tokenSpan(startTok), tokenSpan(semi)),
+        typeAnnotation,
       );
     }
 
-    this.eat(); // =
+    this.expect(TokenType.EQUAL, '=');
     const value = this.parse_expr();
     return mkVarDecl(
       identifier,
       isConstant,
       value,
       mergeSpans(tokenSpan(startTok), value.span),
+      typeAnnotation,
+    );
+  }
+
+  /**
+   * `ubwoko Name = TypeExpr`
+   * Type aliases are statements; the type expression is kept on the AST
+   * and resolved / registered at runtime (not erased).
+   */
+  private parse_type_alias_declaration(): Stmt {
+    const startTok = this.eat(); // ubwoko
+    const nameTok = this.expect(TokenType.IDENTIFIER, 'type name');
+    this.expect(TokenType.EQUAL, '=');
+    const type = this.parse_type_expr();
+    return mkTypeAlias(
+      nameTok.lexeme,
+      type,
+      mergeSpans(tokenSpan(startTok), type.span),
+    );
+  }
+
+  /** `: TypeExpr` optionally followed by `?` for optional types. */
+  private parse_type_annotation(): TypeAnnotation {
+    const colon = this.expect(TokenType.COLON, ':');
+    const type = this.parse_type_expr();
+    let optional = false;
+    let endSpan = type.span;
+    if (this.at().type == TokenType.QUESTION) {
+      const q = this.eat();
+      optional = true;
+      endSpan = tokenSpan(q);
+    }
+    return mkTypeAnnotation(
+      type,
+      optional,
+      mergeSpans(tokenSpan(colon), endSpan),
+    );
+  }
+
+  /**
+   * Type expression grammar (low → high):
+   *   unionType  ::= primaryType ("|" primaryType)*
+   *   primaryType ::= named | object | Fata<…> | "(" type ")"
+   */
+  private parse_type_expr(): TypeNode {
+    let left = this.parse_type_primary();
+    if (this.at().type != TokenType.PIPE) return left;
+
+    const members: TypeNode[] = [left];
+    while (this.at().type == TokenType.PIPE) {
+      this.eat(); // |
+      members.push(this.parse_type_primary());
+    }
+    return mkUnionType(
+      members,
+      mergeSpans(members[0].span, members[members.length - 1].span),
+    );
+  }
+
+  private parse_type_primary(): TypeNode {
+    // Parenthesized type: (ijambo | umubare)
+    if (this.at().type == TokenType.OPEN_PARANTHESES) {
+      const open = this.eat();
+      const inner = this.parse_type_expr();
+      const close = this.expect(TokenType.CLOSE_PARANTHESES, ')');
+      inner.span = mergeSpans(tokenSpan(open), tokenSpan(close));
+      return inner;
+    }
+
+    // Object type: { key: Type, ... }
+    if (this.at().type == TokenType.OPEN_CURLY_BRACES) {
+      return this.parse_object_type();
+    }
+
+    // `porogaramu_ntoya` is a keyword token but also a type name (functions).
+    if (this.at().type == TokenType.POROGARAMU_NTOYA) {
+      const tok = this.eat();
+      return mkNamedType('porogaramu_ntoya', tokenSpan(tok));
+    }
+
+    // Named type or Fata<T, keys>
+    if (this.at().type == TokenType.IDENTIFIER) {
+      const nameTok = this.eat();
+      if (
+        nameTok.lexeme === 'Fata' &&
+        this.at().type == TokenType.LESS_THAN
+      ) {
+        return this.parse_fata_type(nameTok);
+      }
+      return mkNamedType(nameTok.lexeme, tokenSpan(nameTok));
+    }
+
+    return this.fail(
+      'K032',
+      tokenSpan(this.at()),
+      { lexeme: this.at().lexeme },
+      `Expected a type, found ${this.at().lexeme}`,
+    );
+  }
+
+  /** `Fata < TargetType , "key" | "key2" >` (Pick) */
+  private parse_fata_type(fataTok: Token): TypeNode {
+    this.expect(TokenType.LESS_THAN, '<');
+    const target = this.parse_type_expr();
+    this.expect(TokenType.COMMA, ',');
+
+    const keys: string[] = [];
+    const firstKey = this.expect(TokenType.STRING, 'property name string');
+    keys.push(firstKey.lexeme);
+    while (this.at().type == TokenType.PIPE) {
+      this.eat();
+      const keyTok = this.expect(TokenType.STRING, 'property name string');
+      keys.push(keyTok.lexeme);
+    }
+
+    const close = this.expect(TokenType.GREATER_THAN, '>');
+    return mkPickType(
+      target,
+      keys,
+      mergeSpans(tokenSpan(fataTok), tokenSpan(close)),
+    );
+  }
+
+  /** `{ key: Type, key2: Type }` */
+  private parse_object_type(): TypeNode {
+    const startTok = this.eat(); // {
+    const properties: ObjectTypeProperty[] = [];
+
+    while (this.not_eof() && this.at().type != TokenType.CLOSE_CURLY_BRACES) {
+      const keyTok = this.expect(TokenType.IDENTIFIER, 'type property name');
+      this.expect(TokenType.COLON, ':');
+      const propType = this.parse_type_expr();
+      properties.push({
+        key: keyTok.lexeme,
+        type: propType,
+        span: mergeSpans(tokenSpan(keyTok), propType.span),
+      });
+      if (this.at().type != TokenType.CLOSE_CURLY_BRACES) {
+        this.expect(TokenType.COMMA, ',');
+      }
+    }
+
+    const endTok = this.expect(TokenType.CLOSE_CURLY_BRACES, '}');
+    return mkObjectType(
+      properties,
+      mergeSpans(tokenSpan(startTok), tokenSpan(endTok)),
     );
   }
 
@@ -421,6 +593,12 @@ export default class Parser {
       case TokenType.IDENTIFIER: {
         const tok = this.eat();
         return mkIdent(tok.lexeme, tokenSpan(tok));
+      }
+      // `ubwoko` is a keyword for type aliases, but remains a call-able name
+      // in expressions: ubwoko(x) / ubwoko x (if used as bare identifier).
+      case TokenType.UBWOKO: {
+        const tok = this.eat();
+        return mkIdent('ubwoko', tokenSpan(tok));
       }
       case TokenType.INTEGER:
       case TokenType.FLOAT: {
@@ -702,19 +880,12 @@ export default class Parser {
     const nameTok = this.expect(TokenType.IDENTIFIER, 'function name');
     const name = nameTok.lexeme;
 
-    const args = this.parse_args();
-    const params: string[] = [];
+    const params = this.parse_function_params();
 
-    for (const arg of args) {
-      if (arg.kind != 'Identifier') {
-        this.fail(
-          'K022',
-          arg.span,
-          {},
-          'Expected identifier for function parameter',
-        );
-      }
-      params.push((arg as Identifier).symbol);
+    // Optional return type: ): number {
+    let returnType: TypeAnnotation | undefined;
+    if (this.at().type == TokenType.COLON) {
+      returnType = this.parse_type_annotation();
     }
 
     // continue/break inside a function are not tied to an enclosing loop
@@ -734,7 +905,48 @@ export default class Parser {
       params,
       body,
       mergeSpans(tokenSpan(startTok), endSpan),
+      returnType,
     );
+  }
+
+  /**
+   * Parameter list for function declarations: `(a: number, b: string?)`.
+   * Call-site argument lists still use parse_args().
+   */
+  private parse_function_params(): FunctionParameter[] {
+    this.expect(TokenType.OPEN_PARANTHESES, '(');
+    const params: FunctionParameter[] = [];
+
+    if (this.at().type != TokenType.CLOSE_PARANTHESES) {
+      params.push(this.parse_function_param());
+      while (this.at().type == TokenType.COMMA) {
+        this.eat();
+        params.push(this.parse_function_param());
+      }
+    }
+
+    this.expect(TokenType.CLOSE_PARANTHESES, ')');
+    return params;
+  }
+
+  private parse_function_param(): FunctionParameter {
+    if (this.at().type != TokenType.IDENTIFIER) {
+      this.fail(
+        'K022',
+        tokenSpan(this.at()),
+        {},
+        'Expected identifier for function parameter',
+      );
+    }
+    const nameTok = this.eat();
+    const typeAnnotation =
+      this.at().type == TokenType.COLON
+        ? this.parse_type_annotation()
+        : undefined;
+    const span = typeAnnotation
+      ? mergeSpans(tokenSpan(nameTok), typeAnnotation.span)
+      : tokenSpan(nameTok);
+    return mkFunctionParam(nameTok.lexeme, span, typeAnnotation);
   }
 
   private parse_args(): Expr[] {

--- a/src/runtime/environment.ts
+++ b/src/runtime/environment.ts
@@ -7,6 +7,7 @@
 import { Interpreter } from '..';
 import { Identifier, MemberExpr } from '../parser/ast';
 import { createKinError } from '../lib/errors';
+import { Span } from '../lib/span';
 import {
   ArrayVal,
   MK_NATIVE_FN,
@@ -18,28 +19,45 @@ import {
   typeName,
 } from './values';
 import { lookupMethod } from './methods';
+import {
+  assertValueMatchesType,
+  ResolvedType,
+} from './types';
 
 export default class Environment {
   private parent?: Environment;
   private variables: Map<string, RuntimeVal>;
   private constants: Set<string>;
+  /** Declared type for annotated bindings (checked on assign). */
+  private variableTypes: Map<string, ResolvedType>;
+  /** Named type aliases registered in this scope. */
+  private typeAliases: Map<string, ResolvedType>;
 
   constructor(parentENV?: Environment) {
     this.parent = parentENV;
     this.variables = new Map();
     this.constants = new Set();
+    this.variableTypes = new Map();
+    this.typeAliases = new Map();
   }
 
   public declareVar(
     varname: string,
     value: RuntimeVal,
     constant: boolean,
+    type?: ResolvedType,
+    span?: Span,
   ): RuntimeVal {
     if (this.variables.has(varname)) {
       throw createKinError('K007', {
         params: { name: varname },
         message: `Cannot declare variable ${varname}. As it already is defined.`,
       });
+    }
+
+    if (type) {
+      assertValueMatchesType(value, type, span);
+      this.variableTypes.set(varname, type);
     }
 
     this.variables.set(varname, value);
@@ -49,7 +67,11 @@ export default class Environment {
     return value;
   }
 
-  public assignVar(varname: string, value: RuntimeVal): RuntimeVal {
+  public assignVar(
+    varname: string,
+    value: RuntimeVal,
+    span?: Span,
+  ): RuntimeVal {
     const env = this.resolve(varname);
 
     if (env.constants.has(varname)) {
@@ -59,9 +81,39 @@ export default class Environment {
       });
     }
 
+    const declaredType = env.variableTypes.get(varname);
+    if (declaredType) {
+      assertValueMatchesType(value, declaredType, span);
+    }
+
     env.variables.set(varname, value);
 
     return value;
+  }
+
+  /** Look up the declared type of a binding, if any. */
+  public lookupVarType(varname: string): ResolvedType | undefined {
+    const env = this.resolve(varname);
+    return env.variableTypes.get(varname);
+  }
+
+  public declareType(name: string, type: ResolvedType): void {
+    if (this.typeAliases.has(name)) {
+      throw createKinError('K036', {
+        params: { name },
+        message: `Type '${name}' is already defined`,
+      });
+    }
+    // Shadowing a value name is fine; types live in a separate namespace.
+    this.typeAliases.set(name, type);
+  }
+
+  public lookupType(name: string): ResolvedType | undefined {
+    if (this.typeAliases.has(name)) {
+      return this.typeAliases.get(name);
+    }
+    if (this.parent) return this.parent.lookupType(name);
+    return undefined;
   }
 
   public lookupMember(expr: MemberExpr): RuntimeVal {

--- a/src/runtime/eval/expressions.ts
+++ b/src/runtime/eval/expressions.ts
@@ -36,6 +36,7 @@ import { Interpreter } from '../interpreter';
 import { createKinError } from '../../lib/errors';
 import { BreakSignal, ContinueSignal, ReturnSignal } from '../signals';
 import { Span } from '../../lib/span';
+import { assertValueMatchesType } from '../types';
 
 type BinOp = (lhs: RuntimeVal, rhs: RuntimeVal, span?: Span) => RuntimeVal;
 
@@ -138,7 +139,8 @@ export default class EvalExpr {
     }
 
     const varname = (node.assigne as Identifier).symbol;
-    return env.assignVar(varname, Interpreter.evaluate(node.value, env));
+    const value = Interpreter.evaluate(node.value, env);
+    return env.assignVar(varname, value, node.span);
   }
 
   public static eval_object_expr(
@@ -192,7 +194,14 @@ export default class EvalExpr {
       }
 
       for (let i = 0; i < func.parameters.length; i++) {
-        scope.declareVar(func.parameters[i], args[i], false);
+        const paramType = func.parameterTypes?.[i];
+        scope.declareVar(
+          func.parameters[i],
+          args[i],
+          false,
+          paramType,
+          expr.span,
+        );
       }
 
       try {
@@ -201,6 +210,9 @@ export default class EvalExpr {
         }
       } catch (e) {
         if (e instanceof ReturnSignal) {
+          if (func.returnType) {
+            assertValueMatchesType(e.value, func.returnType, expr.span);
+          }
           return e.value;
         }
         if (e instanceof BreakSignal) {
@@ -220,6 +232,10 @@ export default class EvalExpr {
         throw e;
       }
 
+      // Implicit null return when function has a return type annotation.
+      if (func.returnType) {
+        assertValueMatchesType(MK_NULL(), func.returnType, expr.span);
+      }
       return MK_NULL();
     }
 

--- a/src/runtime/eval/statements.ts
+++ b/src/runtime/eval/statements.ts
@@ -11,6 +11,7 @@ import {
   LoopStatement,
   Program,
   Stmt,
+  TypeAliasDeclaration,
   VariableDeclaration,
 } from '../../parser/ast';
 import { createKinError } from '../../lib/errors';
@@ -25,6 +26,7 @@ import {
   isContinueSignal,
   isReturnSignal,
 } from '../signals';
+import { resolveAnnotation, resolveTypeNode } from '../types';
 
 export default class EvalStmt {
   public static eval_program(program: Program, env: Environment): RuntimeVal {
@@ -56,14 +58,33 @@ export default class EvalStmt {
     return lastEvaluated;
   }
 
+  public static eval_type_alias(
+    declaration: TypeAliasDeclaration,
+    env: Environment,
+  ): RuntimeVal {
+    const resolved = resolveTypeNode(declaration.type, env);
+    env.declareType(declaration.name, resolved);
+    return MK_NULL();
+  }
+
   public static eval_function_declaration(
     declaration: FunctionDeclaration,
     env: Environment,
   ): RuntimeVal {
+    const parameters = declaration.parameters.map((p) => p.name);
+    const parameterTypes = declaration.parameters.map((p) =>
+      p.typeAnnotation ? resolveAnnotation(p.typeAnnotation, env) : undefined,
+    );
+    const returnType = declaration.returnType
+      ? resolveAnnotation(declaration.returnType, env)
+      : undefined;
+
     const fn = {
       type: 'fn',
       name: declaration.name,
-      parameters: declaration.parameters,
+      parameters,
+      parameterTypes,
+      returnType,
       declarationEnv: env,
       body: declaration.body,
     } as FunctionValue;
@@ -79,7 +100,17 @@ export default class EvalStmt {
       ? Interpreter.evaluate(declaration.value, env)
       : MK_NULL();
 
-    return env.declareVar(declaration.identifier, value, declaration.constant);
+    const type = declaration.typeAnnotation
+      ? resolveAnnotation(declaration.typeAnnotation, env)
+      : undefined;
+
+    return env.declareVar(
+      declaration.identifier,
+      value,
+      declaration.constant,
+      type,
+      declaration.span,
+    );
   }
 
   public static eval_conditional_statement(

--- a/src/runtime/interpreter.ts
+++ b/src/runtime/interpreter.ts
@@ -21,6 +21,7 @@ import {
   Stmt,
   StringLiteral,
   ConditionalStmt,
+  TypeAliasDeclaration,
   VariableDeclaration,
   UnaryExpr,
   ReturnExpr,
@@ -87,6 +88,11 @@ export class Interpreter {
         case 'VariableDeclaration':
           return EvalStmt.eval_val_declaration(
             astNode as VariableDeclaration,
+            env,
+          );
+        case 'TypeAliasDeclaration':
+          return EvalStmt.eval_type_alias(
+            astNode as TypeAliasDeclaration,
             env,
           );
         case 'FunctionDeclaration':

--- a/src/runtime/types.ts
+++ b/src/runtime/types.ts
@@ -1,0 +1,309 @@
+/***********************************************************************
+ *                         Runtime type system                         *
+ *  Resolve AST type nodes, check values, format human-facing names.   *
+ *  Types are NOT erased: they travel lexer → parser → here at runtime.*
+ ***********************************************************************/
+
+import {
+  NamedType,
+  ObjectType,
+  PickType,
+  TypeAnnotation,
+  TypeNode,
+  UnionType,
+} from '../parser/ast';
+import { createKinError } from '../lib/errors';
+import { Span } from '../lib/span';
+import {
+  ArrayVal,
+  ObjectVal,
+  RuntimeVal,
+  typeName as runtimeValueTypeName,
+} from './values';
+import type Environment from './environment';
+
+/**
+ * Built-in annotation names (Kinyarwanda).
+ * Internal resolved names stay short English tags for comparisons.
+ */
+const PRIMITIVE_NAMES = new Set([
+  'umubare', // number
+  'ijambo', // string
+  'ukuri', // boolean
+  'ubwoko_imiterere', // plain object
+  'urutonde', // array
+  'porogaramu_ntoya', // function (user or native)
+  '_porogaramu_ntoya', // native-fn synonym
+  'ubusa', // null
+]);
+
+/**
+ * Fully resolved type used for runtime checks.
+ * Named aliases are expanded before storage.
+ */
+export type ResolvedType =
+  | { kind: 'primitive'; name: string }
+  | { kind: 'object'; properties: Map<string, ResolvedType> }
+  | { kind: 'union'; members: ResolvedType[] };
+
+// ---------------------------------------------------------------------------
+// Resolution
+// ---------------------------------------------------------------------------
+
+/**
+ * Resolve a TypeAnnotation into a ResolvedType.
+ * Optional annotations (`T?`) become `T | null`.
+ */
+export function resolveAnnotation(
+  annotation: TypeAnnotation,
+  env: Environment,
+): ResolvedType {
+  const base = resolveTypeNode(annotation.type, env);
+  if (!annotation.optional) return base;
+  return {
+    kind: 'union',
+    members: [base, { kind: 'primitive', name: 'null' }],
+  };
+}
+
+export function resolveTypeNode(node: TypeNode, env: Environment): ResolvedType {
+  switch (node.kind) {
+    case 'NamedType':
+      return resolveNamedType(node, env);
+    case 'ObjectType':
+      return resolveObjectType(node, env);
+    case 'UnionType':
+      return resolveUnionType(node, env);
+    case 'PickType':
+      return resolvePickType(node, env);
+    default: {
+      const _exhaustive: never = node;
+      return _exhaustive;
+    }
+  }
+}
+
+function resolveNamedType(node: NamedType, env: Environment): ResolvedType {
+  const name = node.name;
+
+  // Built-in primitives (Kinyarwanda surface → internal tag)
+  switch (name) {
+    case 'umubare':
+      return { kind: 'primitive', name: 'number' };
+    case 'ijambo':
+      return { kind: 'primitive', name: 'string' };
+    case 'ukuri':
+      return { kind: 'primitive', name: 'boolean' };
+    case 'ubwoko_imiterere':
+      return { kind: 'primitive', name: 'object' };
+    case 'urutonde':
+      return { kind: 'primitive', name: 'array' };
+    case 'porogaramu_ntoya':
+    case '_porogaramu_ntoya':
+      // Both user and native functions match porogaramu_ntoya.
+      return { kind: 'primitive', name: 'fn' };
+    case 'ubusa':
+      return { kind: 'primitive', name: 'null' };
+    default:
+      break;
+  }
+
+  // User-defined type alias
+  const alias = env.lookupType(name);
+  if (alias) return alias;
+
+  throw createKinError('K033', {
+    span: node.span,
+    params: { name },
+    message: `Unknown type '${name}'`,
+  });
+}
+
+function resolveObjectType(node: ObjectType, env: Environment): ResolvedType {
+  const properties = new Map<string, ResolvedType>();
+  for (const prop of node.properties) {
+    if (properties.has(prop.key)) {
+      throw createKinError('K036', {
+        span: prop.span,
+        params: { name: prop.key },
+        message: `Duplicate property '${prop.key}' in object type`,
+      });
+    }
+    properties.set(prop.key, resolveTypeNode(prop.type, env));
+  }
+  return { kind: 'object', properties };
+}
+
+function resolveUnionType(node: UnionType, env: Environment): ResolvedType {
+  const members = node.members.map((m) => resolveTypeNode(m, env));
+  // Flatten nested unions
+  const flat: ResolvedType[] = [];
+  for (const m of members) {
+    if (m.kind === 'union') flat.push(...m.members);
+    else flat.push(m);
+  }
+  return { kind: 'union', members: flat };
+}
+
+function resolvePickType(node: PickType, env: Environment): ResolvedType {
+  const target = resolveTypeNode(node.target, env);
+  if (target.kind !== 'object') {
+    const detail = `Fata requires an object type (ubwoko_imiterere), got ${formatResolvedType(target)}`;
+    throw createKinError('K034', {
+      span: node.span,
+      params: { message: detail },
+      message: detail,
+    });
+  }
+
+  const properties = new Map<string, ResolvedType>();
+  for (const key of node.keys) {
+    const propType = target.properties.get(key);
+    if (!propType) {
+      const detail = `Fata key '${key}' does not exist on type ${formatResolvedType(target)}`;
+      throw createKinError('K034', {
+        span: node.span,
+        params: { message: detail },
+        message: detail,
+      });
+    }
+    properties.set(key, propType);
+  }
+  return { kind: 'object', properties };
+}
+
+// ---------------------------------------------------------------------------
+// Checking
+// ---------------------------------------------------------------------------
+
+/**
+ * Whether a runtime value satisfies a resolved type (structural for objects).
+ */
+export function valueMatchesType(
+  value: RuntimeVal,
+  expected: ResolvedType,
+): boolean {
+  if (expected.kind === 'union') {
+    return expected.members.some((m) => valueMatchesType(value, m));
+  }
+
+  if (expected.kind === 'primitive') {
+    return valueMatchesPrimitive(value, expected.name);
+  }
+
+  // Object type — structural: value must be object and every required
+  // property must match. Extra properties are allowed (open structural).
+  if (value.type !== 'object') return false;
+  const obj = value as ObjectVal;
+  for (const [key, propType] of expected.properties) {
+    const propVal = obj.properties.get(key);
+    if (propVal === undefined) return false;
+    if (!valueMatchesType(propVal, propType)) return false;
+  }
+  return true;
+}
+
+function valueMatchesPrimitive(value: RuntimeVal, name: string): boolean {
+  switch (name) {
+    case 'number':
+      return value.type === 'number';
+    case 'string':
+      return value.type === 'string';
+    case 'boolean':
+      return value.type === 'boolean';
+    case 'null':
+      return value.type === 'null';
+    case 'array':
+      return value.type === 'array';
+    case 'fn':
+      // User functions and native functions both count as fn.
+      return value.type === 'fn' || value.type === 'native-fn';
+    case 'object':
+      // Bare `object` accepts any object (not arrays).
+      return value.type === 'object';
+    default:
+      return false;
+  }
+}
+
+/**
+ * Human-facing Kinyarwanda name for a runtime value's type (error messages).
+ */
+export function valueTypeLabel(value: RuntimeVal): string {
+  return runtimeValueTypeName(value);
+}
+
+/**
+ * Human-facing Kinyarwanda name for a resolved type (error messages).
+ */
+export function formatResolvedType(type: ResolvedType): string {
+  switch (type.kind) {
+    case 'primitive':
+      return primitiveSurfaceName(type.name);
+    case 'union':
+      return type.members.map(formatResolvedType).join(' | ');
+    case 'object': {
+      const parts: string[] = [];
+      for (const [key, propType] of type.properties) {
+        parts.push(`${key}: ${formatResolvedType(propType)}`);
+      }
+      return `{ ${parts.join(', ')} }`;
+    }
+  }
+}
+
+/** Map internal tags → Kinyarwanda surface names. */
+function primitiveSurfaceName(internal: string): string {
+  switch (internal) {
+    case 'number':
+      return 'umubare';
+    case 'string':
+      return 'ijambo';
+    case 'boolean':
+      return 'ukuri';
+    case 'object':
+      return 'ubwoko_imiterere';
+    case 'array':
+      return 'urutonde';
+    case 'fn':
+      return 'porogaramu_ntoya';
+    case 'null':
+      return 'ubusa';
+    default:
+      return internal;
+  }
+}
+
+/**
+ * Throw a clear assignment type-mismatch error.
+ * Message shape (user-requested):
+ *   Cannot assign a number to a string, expected a string instead.
+ */
+export function assertValueMatchesType(
+  value: RuntimeVal,
+  expected: ResolvedType,
+  span?: Span,
+): void {
+  if (valueMatchesType(value, expected)) return;
+
+  const got = valueTypeLabel(value);
+  const want = formatResolvedType(expected);
+  throw createKinError('K035', {
+    span,
+    params: { got, expected: want },
+    message: `Cannot assign a ${got} to a ${want}, expected a ${want} instead.`,
+  });
+}
+
+/**
+ * Check that an array's elements are all of a homogeneous primitive when
+ * the annotation is just `urutonde` — no element-level check (open array).
+ * Kept as a named helper for future element types.
+ */
+export function isArrayValue(value: RuntimeVal): value is ArrayVal {
+  return value.type === 'array';
+}
+
+export function isBuiltinTypeName(name: string): boolean {
+  return PRIMITIVE_NAMES.has(name);
+}

--- a/src/runtime/values.ts
+++ b/src/runtime/values.ts
@@ -5,6 +5,7 @@
 
 import { Stmt } from '../parser/ast';
 import Environment from './environment';
+import type { ResolvedType } from './types';
 
 export type ValueType =
   | 'null'
@@ -55,6 +56,10 @@ export interface FunctionValue extends RuntimeVal {
   type: 'fn';
   name: string;
   parameters: string[];
+  /** Resolved parameter types (aligned with parameters; undefined = untyped). */
+  parameterTypes?: (ResolvedType | undefined)[];
+  /** Resolved return type when annotated. */
+  returnType?: ResolvedType;
   declarationEnv: Environment;
   body: Stmt[];
 }
@@ -95,12 +100,29 @@ export function MK_ARRAY(elements: RuntimeVal[] = []) {
 }
 
 /**
- * Human-facing type name for ubwoko and error messages.
- * Arrays report as "urutonde"; other types keep their internal name.
+ * Human-facing Kinyarwanda type name for `ubwoko()` and error messages.
  */
 export function typeName(value: RuntimeVal): string {
-  if (value.type === 'array') return 'urutonde';
-  return value.type;
+  switch (value.type) {
+    case 'number':
+      return 'umubare';
+    case 'string':
+      return 'ijambo';
+    case 'boolean':
+      return 'ukuri';
+    case 'object':
+      return 'ubwoko_imiterere';
+    case 'array':
+      return 'urutonde';
+    case 'fn':
+      return 'porogaramu_ntoya';
+    case 'native-fn':
+      return '_porogaramu_ntoya';
+    case 'null':
+      return 'ubusa';
+    default:
+      return value.type;
+  }
 }
 
 /** Deep-ish structural equality used by == / != and array.contains. */

--- a/tests/errors.test.ts
+++ b/tests/errors.test.ts
@@ -152,17 +152,14 @@ describe('Lexer throws KinSyntaxError', () => {
     expect(err.code).toBe('K003');
   });
 
-  test('lone pipe', () => {
-    const err = expectThrownKinError(
-      () => new Lexer('a | b').tokenize(),
-      KinSyntaxError,
-      {
-        code: 'K004',
-        ERRNAME: 'SyntaxError',
-        ERRCODE: 'E_SYNTAX',
-      },
-    );
-    expect(err).toBeInstanceOf(KinSyntaxError);
+  test('lone pipe is tokenized for type unions (not a lexer error)', () => {
+    const tokens = new Lexer('string | number').tokenize();
+    expect(tokens.map((t) => t.lexeme)).toEqual([
+      'string',
+      '|',
+      'number',
+      'EOF',
+    ]);
   });
 });
 

--- a/tests/globals.test.ts
+++ b/tests/globals.test.ts
@@ -579,13 +579,13 @@ describe('createGlobalEnv', () => {
 
   describe('ubwoko', () => {
     test('returns the runtime type name', () => {
-      expect(asString(evaluate('ubwoko(1)').result)).toBe('number');
-      expect(asString(evaluate('ubwoko("kin")').result)).toBe('string');
-      expect(asString(evaluate('ubwoko(nibyo)').result)).toBe('boolean');
-      expect(asString(evaluate('ubwoko(ubusa)').result)).toBe('null');
+      expect(asString(evaluate('ubwoko(1)').result)).toBe('umubare');
+      expect(asString(evaluate('ubwoko("kin")').result)).toBe('ijambo');
+      expect(asString(evaluate('ubwoko(nibyo)').result)).toBe('ukuri');
+      expect(asString(evaluate('ubwoko(ubusa)').result)).toBe('ubusa');
       expect(asString(evaluate('ubwoko([1])').result)).toBe('urutonde');
       expect(asString(evaluate('ubwoko(tangaza_amakuru)').result)).toBe(
-        'native-fn',
+        '_porogaramu_ntoya',
       );
       expect(
         asString(
@@ -594,7 +594,7 @@ describe('createGlobalEnv', () => {
             ubwoko(f)
           `).result,
         ),
-      ).toBe('fn');
+      ).toBe('porogaramu_ntoya');
     });
 
     test('requires an argument', () => {

--- a/tests/member-expression.test.ts
+++ b/tests/member-expression.test.ts
@@ -234,7 +234,7 @@ describe('Member Expression (computed + dot access) Tests', () => {
           reka x = 5
           x.foo
         `),
-      ).toThrow("Cannot access property 'foo' of number");
+      ).toThrow("Cannot access property 'foo' of umubare");
     });
 
     test('should throw a Kin error when walking through a primitive element', () => {
@@ -243,7 +243,7 @@ describe('Member Expression (computed + dot access) Tests', () => {
           reka arr = [5]
           arr[0][0]
         `),
-      ).toThrow("Cannot access property '0' of number");
+      ).toThrow("Cannot access property '0' of umubare");
     });
 
     test('should return ubusa (null) for a missing key instead of throwing', () => {

--- a/tests/parser.test.ts
+++ b/tests/parser.test.ts
@@ -47,7 +47,11 @@ describe('Parser', () => {
         {
           kind: 'FunctionDeclaration',
           name: 'add',
-          parameters: ['a', 'b'],
+          parameters: [
+            { name: 'a', typeAnnotation: undefined },
+            { name: 'b', typeAnnotation: undefined },
+          ],
+          returnType: undefined,
           body: [
             {
               kind: 'ReturnExpr',
@@ -59,6 +63,156 @@ describe('Parser', () => {
               },
             },
           ],
+        },
+      ],
+    });
+  });
+
+  test('should parse typed function parameters and return type', () => {
+    expect(
+      parse(
+        'porogaramu_ntoya add(a: umubare, b: umubare): umubare { tanga a + b }',
+      ),
+    ).toEqual({
+      kind: 'Program',
+      body: [
+        {
+          kind: 'FunctionDeclaration',
+          name: 'add',
+          parameters: [
+            {
+              name: 'a',
+              typeAnnotation: {
+                kind: 'TypeAnnotation',
+                optional: false,
+                type: { kind: 'NamedType', name: 'umubare' },
+              },
+            },
+            {
+              name: 'b',
+              typeAnnotation: {
+                kind: 'TypeAnnotation',
+                optional: false,
+                type: { kind: 'NamedType', name: 'umubare' },
+              },
+            },
+          ],
+          returnType: {
+            kind: 'TypeAnnotation',
+            optional: false,
+            type: { kind: 'NamedType', name: 'umubare' },
+          },
+          body: [
+            {
+              kind: 'ReturnExpr',
+              value: {
+                kind: 'BinaryExpr',
+                operator: '+',
+                left: { kind: 'Identifier', symbol: 'a' },
+                right: { kind: 'Identifier', symbol: 'b' },
+              },
+            },
+          ],
+        },
+      ],
+    });
+  });
+
+  test('should parse ubwoko alias, union, Fata, and nested object types', () => {
+    expect(
+      parse(`
+        ubwoko Address = { city: ijambo }
+        ubwoko Person = { name: ijambo, address: Address }
+        ubwoko Id = ijambo | umubare
+        ubwoko NameOnly = Fata<Person, "name">
+        reka p: Person = { name: "Keza", address: { city: "Kigali" } }
+      `),
+    ).toEqual({
+      kind: 'Program',
+      body: [
+        {
+          kind: 'TypeAliasDeclaration',
+          name: 'Address',
+          type: {
+            kind: 'ObjectType',
+            properties: [
+              {
+                key: 'city',
+                type: { kind: 'NamedType', name: 'ijambo' },
+              },
+            ],
+          },
+        },
+        {
+          kind: 'TypeAliasDeclaration',
+          name: 'Person',
+          type: {
+            kind: 'ObjectType',
+            properties: [
+              {
+                key: 'name',
+                type: { kind: 'NamedType', name: 'ijambo' },
+              },
+              {
+                key: 'address',
+                type: { kind: 'NamedType', name: 'Address' },
+              },
+            ],
+          },
+        },
+        {
+          kind: 'TypeAliasDeclaration',
+          name: 'Id',
+          type: {
+            kind: 'UnionType',
+            members: [
+              { kind: 'NamedType', name: 'ijambo' },
+              { kind: 'NamedType', name: 'umubare' },
+            ],
+          },
+        },
+        {
+          kind: 'TypeAliasDeclaration',
+          name: 'NameOnly',
+          type: {
+            kind: 'PickType',
+            target: { kind: 'NamedType', name: 'Person' },
+            keys: ['name'],
+          },
+        },
+        {
+          kind: 'VariableDeclaration',
+          constant: false,
+          identifier: 'p',
+          typeAnnotation: {
+            kind: 'TypeAnnotation',
+            optional: false,
+            type: { kind: 'NamedType', name: 'Person' },
+          },
+          value: {
+            kind: 'ObjectLiteral',
+            properties: [
+              {
+                kind: 'Property',
+                key: 'name',
+                value: { kind: 'StringLiteral', value: 'Keza' },
+              },
+              {
+                kind: 'Property',
+                key: 'address',
+                value: {
+                  kind: 'ObjectLiteral',
+                  properties: [
+                    {
+                      kind: 'Property',
+                      key: 'city',
+                      value: { kind: 'StringLiteral', value: 'Kigali' },
+                    },
+                  ],
+                },
+              },
+            ],
+          },
         },
       ],
     });

--- a/tests/types.test.ts
+++ b/tests/types.test.ts
@@ -1,0 +1,224 @@
+import { describe, test, expect } from 'vitest';
+import TokenType from '../src/lexer/tokens';
+import Lexer from '../src/lexer/lexer';
+import { KinTypeError } from '../src/lib/errors';
+import {
+  asNumber,
+  asString,
+  evaluate,
+  expectKinError,
+  expectThrownKinError,
+} from './helpers';
+
+describe('Type system — lexer', () => {
+  test('tokenizes ubwoko keyword, pipe, and question mark', () => {
+    const tokens = new Lexer(
+      'ubwoko Person = { name: ijambo } reka x: umubare? = ubusa a | b',
+    ).tokenize();
+    const kinds = tokens.map((t) => t.type);
+    expect(kinds).toContain(TokenType.UBWOKO);
+    expect(kinds).toContain(TokenType.PIPE);
+    expect(kinds).toContain(TokenType.QUESTION);
+    expect(kinds).toContain(TokenType.COLON);
+  });
+});
+
+describe('Type system — runtime checks', () => {
+  test('accepts matching primitive annotations', () => {
+    const { env } = evaluate(`
+      reka age: umubare = 25
+      reka name: ijambo = "Keza"
+      reka ok: ukuri = nibyo
+      reka list: urutonde = [1, 2]
+    `);
+    expect(asNumber(env.lookupVar('age'))).toBe(25);
+    expect(asString(env.lookupVar('name'))).toBe('Keza');
+  });
+
+  test('rejects umubare assigned to ijambo', () => {
+    const err = expectKinError('reka name: ijambo = 42', 'K035');
+    expect(err).toBeInstanceOf(KinTypeError);
+    expect(err.message).toMatch(/Cannot assign a umubare to a ijambo/i);
+  });
+
+  test('rejects reassignment that breaks annotation', () => {
+    expectKinError(
+      `
+      reka name: ijambo = "Keza"
+      name = 10
+    `,
+      'K035',
+    );
+  });
+
+  test('optional type accepts ubusa', () => {
+    const { env } = evaluate('reka maybe: umubare? = ubusa');
+    expect(env.lookupVar('maybe').type).toBe('null');
+  });
+
+  test('required type rejects ubusa', () => {
+    expectKinError('reka score: umubare = ubusa', 'K035');
+  });
+
+  test('union type accepts either member', () => {
+    const { env } = evaluate(`
+      ubwoko Id = ijambo | umubare
+      reka a: Id = "x"
+      reka b: Id = 7
+    `);
+    expect(asString(env.lookupVar('a'))).toBe('x');
+    expect(asNumber(env.lookupVar('b'))).toBe(7);
+  });
+
+  test('union type rejects other types', () => {
+    expectKinError(
+      `
+      ubwoko Id = ijambo | umubare
+      reka a: Id = nibyo
+    `,
+      'K035',
+    );
+  });
+
+  test('object type with nested type chaining', () => {
+    const { env } = evaluate(`
+      ubwoko Address = { city: ijambo, street: ijambo }
+      ubwoko Person = { name: ijambo, address: Address }
+      reka p: Person = {
+        name: "Keza",
+        address: { city: "Kigali", street: "KG 1" }
+      }
+    `);
+    expect(env.lookupVar('p').type).toBe('object');
+  });
+
+  test('object type rejects missing property', () => {
+    expectKinError(
+      `
+      ubwoko Person = { name: ijambo, age: umubare }
+      reka p: Person = { name: "Keza" }
+    `,
+      'K035',
+    );
+  });
+
+  test('object type rejects wrong nested type', () => {
+    expectKinError(
+      `
+      ubwoko Address = { city: ijambo }
+      ubwoko Person = { address: Address }
+      reka p: Person = { address: { city: 1 } }
+    `,
+      'K035',
+    );
+  });
+
+  test('Fata keeps only selected keys', () => {
+    const { env } = evaluate(`
+      ubwoko Person = { name: ijambo, age: umubare, city: ijambo }
+      ubwoko NameOnly = Fata<Person, "name">
+      reka n: NameOnly = { name: "Keza" }
+    `);
+    expect(env.lookupVar('n').type).toBe('object');
+  });
+
+  test('Fata with multiple keys', () => {
+    evaluate(`
+      ubwoko Person = { name: ijambo, age: umubare, city: ijambo }
+      ubwoko NameAge = Fata<Person, "name" | "age">
+      reka n: NameAge = { name: "Keza", age: 20 }
+    `);
+  });
+
+  test('Fata rejects missing key on source type', () => {
+    expectThrownKinError(
+      () =>
+        evaluate(`
+          ubwoko Person = { name: ijambo }
+          ubwoko Bad = Fata<Person, "age">
+        `),
+      KinTypeError,
+      { code: 'K034' },
+    );
+  });
+
+  test('typed function parameters are checked at call time', () => {
+    expectKinError(
+      `
+      porogaramu_ntoya add(a: umubare, b: umubare): umubare {
+        tanga a + b
+      }
+      add("1", 2)
+    `,
+      'K035',
+    );
+  });
+
+  test('typed function return value is checked', () => {
+    expectKinError(
+      `
+      porogaramu_ntoya bad(): umubare {
+        tanga "nope"
+      }
+      bad()
+    `,
+      'K035',
+    );
+  });
+
+  test('typed function happy path', () => {
+    const { result } = evaluate(`
+      porogaramu_ntoya add(a: umubare, b: umubare): umubare {
+        tanga a + b
+      }
+      add(2, 3)
+    `);
+    expect(asNumber(result)).toBe(5);
+  });
+
+  test('porogaramu_ntoya annotation accepts functions', () => {
+    evaluate(`
+      porogaramu_ntoya add(a: umubare, b: umubare): umubare {
+        tanga a + b
+      }
+      reka f: porogaramu_ntoya = add
+      reka print: _porogaramu_ntoya = tangaza_amakuru
+    `);
+  });
+
+  test('ubwoko() still reports runtime type names in Kinyarwanda', () => {
+    const { result } = evaluate('ubwoko(5)');
+    expect(asString(result)).toBe('umubare');
+  });
+
+  test('ubwoko as type keyword and as function coexist', () => {
+    const { result } = evaluate(`
+      ubwoko Id = umubare
+      reka x: Id = 3
+      ubwoko(x)
+    `);
+    expect(asString(result)).toBe('umubare');
+  });
+
+  test('unknown type name is an error', () => {
+    expectKinError('reka x: DoesNotExist = 1', 'K033');
+  });
+
+  test('duplicate type alias is an error', () => {
+    expectKinError(
+      `
+      ubwoko A = umubare
+      ubwoko A = ijambo
+    `,
+      'K036',
+    );
+  });
+
+  test('unannotated variables stay dynamic', () => {
+    const { env } = evaluate(`
+      reka x = 1
+      x = "now a string"
+    `);
+    expect(asString(env.lookupVar('x'))).toBe('now a string');
+  });
+});


### PR DESCRIPTION
## Summary of Changes

Implements runtime type safety for Kin: type annotations are tokenized, parsed, kept on the AST, and checked at runtime. Type names and the type-alias keyword use Kinyarwanda.

Fixes #256

## Description of Changes

- **Annotations** on `reka` / `ntahinduka`, function parameters, and return types
- **Optional types** with `?` (e.g. `umubare?` allows `ubusa`)
- **`ubwoko` type aliases**: object shapes, unions (`A | B`), nesting, and `Fata` (Pick)
- **Dual `ubwoko`**: type-alias keyword (`ubwoko Person = …`) and typeof function (`ubwoko(x)`)
- **Built-in type names**: `umubare`, `ijambo`, `ukuri`, `ubwoko_imiterere`, `urutonde`, `porogaramu_ntoya`, `_porogaramu_ntoya`, `ubusa`
- Mismatch errors: `Cannot assign a umubare to a ijambo, expected a ijambo instead.`
- Updated `examples/`, `grammar.bnf`, error catalog (K032–K036), README

Companion PRs:
- vscode-intellisense (LSP/highlighting)
- wiki (EN + RW docs)
- editor (playground sample)

## Testing

- [x] `npm test` — 248 tests passing
- [x] `examples/types.kin` and other examples run successfully
- [x] Type mismatch, union, Fata, nested types, and typed functions covered in `tests/types.test.ts`

## Checklist

* [x] I have performed a self-review of my code.
* [x] I have added thorough tests for any new features.
* [x] I have updated the documentation to reflect the changes made in this pull request.
* [x] I have addressed any comments or questions raised by reviewers.

## Additional Notes

Issue #256 also mentioned global/per-file type-safety modes (`on`/`off`/`strict`). This PR focuses on annotations and runtime checks when types are present; unannotated bindings stay dynamic. Mode switches can follow in a separate PR if desired.