### PR TITLE
feat: OOP (imiterere, rema, visibility, types)

### DIFF
--- a/docs/errors.md
+++ b/docs/errors.md
@@ -54,5 +54,12 @@ Host programs can branch on `instanceof`, `ERRNAME`, or `ERRCODE`.
 | K034 | TypeError | Invalid Fata type | `Fata<umubare, "a">` | Fata only works on object types with existing keys. |
 | K035 | TypeError | Cannot assign a {got} to a {expected} | `reka x: ijambo = 1` | Assign a value that matches the annotation. |
 | K036 | TypeError | Type '{name}' is already defined | two `ubwoko Person = ...` | Use a unique type name. |
+| K037 | SyntaxError | Class already has a tegura constructor | two tegura in one class | Only one constructor per class. |
+| K038 | SyntaxError | Field init must use _.<name> | bad field form in tegura | Write `rusange _.field = …`. |
+| K039 | TypeError | Cannot assign to method | `obj.method = …` | Methods are not assignable. |
+| K040 | TypeError | Field does not exist | assign unknown field | Create fields only in tegura. |
+| K041 | TypeError | Cannot access private member | read `bwite` from outside | Use a public method wrapper. |
+| K042 | TypeError | Not a class (imiterere) | `rema 5()` | Pass a class value to rema. |
+| K043 | TypeError | Field already defined | duplicate field in tegura | Assign each field once in tegura. |
 
 Messages are loaded from `src/messages/rw.json` (default) and `src/messages/en.json` (`KIN_LANG=en`).

--- a/grammar.bnf
+++ b/grammar.bnf
@@ -26,6 +26,7 @@ program ::= statement*
 
 statement ::= variableDeclaration
             | typeAliasDeclaration
+            | classDeclaration
             | functionDeclaration
             | loopStatement
             | breakStatement
@@ -43,8 +44,30 @@ variableDeclaration ::= "reka" identifier typeAnnotation? (";" | "=" expression)
                       | "ntahinduka" identifier typeAnnotation? "=" expression
 
 ; Named type alias (not erased). Supports object types, unions, Fata, nesting.
-; `ubwoko` is also the typeof function in expressions: ubwoko(x).
+; `ubwoko` is also a prefix typeof operator: ubwoko x / ubwoko(x).
 typeAliasDeclaration ::= "ubwoko" identifier "=" typeExpression
+
+; OOP: class declaration. Fields are created only inside tegura with
+; visibility _.name = expr. Methods require rusange or bwite.
+classDeclaration ::= "imiterere" identifier ("ikomoka" identifier)? "{"
+                       classMember*
+                     "}"
+
+classMember ::= constructorDecl | methodDecl
+
+constructorDecl ::= "tegura" "(" parameterList? ")" "{"
+                      (fieldInit | statement)*
+                    "}"
+
+fieldInit ::= ("rusange" | "bwite") "_" "." identifier "=" expression
+
+methodDecl ::= ("rusange" | "bwite") "porogaramu_ntoya" identifier
+               "(" parameterList? ")" typeAnnotation? block
+
+; Instantiate: rema Class(args) then optional member/call chain.
+; rema binds tighter than binary ops; (rema C(…)).method() is valid.
+remaExpression ::= "rema" memberExpression "(" argumentList? ")"
+                   (memberSuffix | "(" argumentList? ")")*
 
 functionDeclaration ::= "porogaramu_ntoya" identifier "(" parameterList? ")"
                         typeAnnotation? block
@@ -161,7 +184,9 @@ primaryExpression ::= identifier
                     | unaryExpression
 
 ; ! and unary - apply to a primary expression.
+; ubwoko is a prefix typeof (tighter than every binary operator).
 unaryExpression ::= ("!" | "-") primaryExpression
+                  | "ubwoko" callMemberExpression
 
 ; Keys are identifiers only (not string literals).
 ; Shorthand { key } looks up `key` in the current environment at runtime.
@@ -220,7 +245,8 @@ stringLiteral ::= '"' { anyCharacterExceptQuoteOrNewline } '"'
 ; subiramo_niba  hagarara  komeza
 ; niba  nanone_niba  niba_byanze
 ; gereranya  usanze  ibindi
-; ubwoko   (type alias keyword; also typeof function name)
+; ubwoko     (type alias keyword + typeof prefix operator)
+; imiterere  tegura  rema  rusange  bwite  ikomoka
 
 ; Built-in type names:
 ; umubare  ijambo  ukuri  ubwoko_imiterere  urutonde

--- a/scripts/run-examples.sh
+++ b/scripts/run-examples.sh
@@ -1,5 +1,6 @@
 #!/usr/bin/env bash
 # Run every shipped example with the built Kin CLI (dist/bin/kin.js).
+# Includes top-level examples/*.kin and OOP samples under examples/oop/*.kin.
 # Interactive examples (injiza_amakuru / prompt-sync) need a real TTY, so they
 # are exercised in tests/examples.test.ts instead of this script.
 set -euo pipefail
@@ -18,27 +19,29 @@ failed=0
 ran=0
 
 shopt -s nullglob
-examples=(examples/*.kin)
+examples=(examples/*.kin examples/oop/*.kin)
 if [[ ${#examples[@]} -eq 0 ]]; then
-  echo "No example programs found in examples/" >&2
+  echo "No example programs found in examples/ or examples/oop/" >&2
   exit 1
 fi
 
 for example in "${examples[@]}"; do
+  # Relative path for display: arrays.kin or oop/class-basics.kin
+  rel="${example#examples/}"
   name="$(basename "$example")"
   case "$name" in
     io.kin|switch.kin)
-      echo "SKIP $name (interactive; covered by tests/examples.test.ts)"
+      echo "SKIP $rel (interactive; covered by tests/examples.test.ts)"
       continue
       ;;
   esac
 
-  echo "RUN  $name"
+  echo "RUN  $rel"
   if node "$KIN_BIN" run "$example"; then
-    echo "PASS $name"
+    echo "PASS $rel"
     ran=$((ran + 1))
   else
-    echo "FAIL $name" >&2
+    echo "FAIL $rel" >&2
     failed=1
   fi
 done

--- a/src/lexer/lexer.ts
+++ b/src/lexer/lexer.ts
@@ -211,6 +211,18 @@ class Lexer {
         return TokenType.IBINDI;
       case 'ubwoko':
         return TokenType.UBWOKO;
+      case 'imiterere':
+        return TokenType.IMITERERE;
+      case 'tegura':
+        return TokenType.TEGURA;
+      case 'rema':
+        return TokenType.REMA;
+      case 'rusange':
+        return TokenType.RUSANGE;
+      case 'bwite':
+        return TokenType.BWITE;
+      case 'ikomoka':
+        return TokenType.IKOMOKA;
       default:
         return undefined;
     }

--- a/src/lexer/tokens.ts
+++ b/src/lexer/tokens.ts
@@ -65,9 +65,24 @@ enum TokenType {
   IBINDI,
   /**
    * Type-related keyword: type alias declaration (`ubwoko Person = …`)
-   * and still usable as the typeof function name in expressions (`ubwoko(x)`).
+   * and typeof prefix operator / paren form (`ubwoko x`, `ubwoko(x)`).
    */
   UBWOKO,
+
+  /* OOP keywords */
+  /** Class declaration: `imiterere Name { … }` */
+  IMITERERE,
+  /** Constructor: `tegura(params) { … }` */
+  TEGURA,
+  /** Instantiate: `rema ClassName(args)` */
+  REMA,
+  /** Public visibility */
+  RUSANGE,
+  /** Private visibility */
+  BWITE,
+  /** Inheritance: `imiterere Child ikomoka Parent` */
+  IKOMOKA,
+
   EOF,
 }
 

--- a/src/lib/errors.ts
+++ b/src/lib/errors.ts
@@ -66,6 +66,13 @@ export const CODE_CATEGORY: Readonly<Record<string, KinErrorName>> = {
   K034: 'TypeError',
   K035: 'TypeError',
   K036: 'TypeError',
+  K037: 'SyntaxError',
+  K038: 'SyntaxError',
+  K039: 'TypeError',
+  K040: 'TypeError',
+  K041: 'TypeError',
+  K042: 'TypeError',
+  K043: 'TypeError',
 
   // Runtime — control flow, exit, internals
   K013: 'RuntimeError',

--- a/src/messages/en.json
+++ b/src/messages/en.json
@@ -34,5 +34,12 @@
   "K033": "Unknown type '{name}'",
   "K034": "Invalid Pick type: {message}",
   "K035": "Cannot assign a {got} to a {expected}, expected a {expected} instead",
-  "K036": "Type '{name}' is already defined"
+  "K036": "Type '{name}' is already defined",
+  "K037": "Class already has a tegura constructor",
+  "K038": "Field initialization must use _.<name> inside tegura",
+  "K039": "Cannot assign to method '{name}'",
+  "K040": "Field '{name}' does not exist on {klass}; fields are created only in tegura",
+  "K041": "Cannot access private member '{name}'",
+  "K042": "'{name}' is not a class (imiterere)",
+  "K043": "Field '{name}' is already defined"
 }

--- a/src/messages/rw.json
+++ b/src/messages/rw.json
@@ -34,5 +34,12 @@
   "K033": "Ubwoko '{name}' ntabwo buzwi",
   "K034": "Ubwoko bwa Pick si bwo: {message}",
   "K035": "Ntushobora guha {got} kuri {expected}, byari biteganyijwe {expected}",
-  "K036": "Ubwoko '{name}' busanzwe buhari"
+  "K036": "Ubwoko '{name}' busanzwe buhari",
+  "K037": "Iyi imiterere ifite tegura isanzwe ihari",
+  "K038": "Gushyiraho umwanya ugomba gukoresha _.<izina> muri tegura",
+  "K039": "Ntushobora guhindura umumaro '{name}'",
+  "K040": "Umwanya '{name}' ntihari kuri {klass}; umwanya uremwa muri tegura gusa",
+  "K041": "Ntushobora kugera kuri '{name}' (bwite)",
+  "K042": "'{name}' ntabwo ari imiterere",
+  "K043": "Umwanya '{name}' usanzwe uhari"
 }

--- a/src/parser/ast.ts
+++ b/src/parser/ast.ts
@@ -11,6 +11,8 @@ export type NodeType =
   | 'VariableDeclaration'
   | 'FunctionDeclaration'
   | 'TypeAliasDeclaration'
+  | 'ClassDeclaration'
+  | 'FieldInitStatement'
   | 'LoopStatement'
   | 'BreakStatement'
   | 'ContinueStatement'
@@ -23,6 +25,7 @@ export type NodeType =
   | 'BinaryExpr'
   | 'UnaryExpr'
   | 'ReturnExpr'
+  | 'RemaExpr'
 
   // Literals
   | 'ObjectLiteral'
@@ -147,6 +150,54 @@ export interface TypeAliasDeclaration extends Stmt {
   kind: 'TypeAliasDeclaration';
   name: string;
   type: TypeNode;
+}
+
+export type Visibility = 'rusange' | 'bwite';
+
+/**
+ * Class declaration: `imiterere Name ikomoka Parent? { … }`
+ */
+export interface ClassDeclaration extends Stmt {
+  kind: 'ClassDeclaration';
+  name: string;
+  /** Parent class name when `ikomoka Parent` is present. */
+  parentName?: string;
+  constructor?: ClassConstructor;
+  methods: ClassMethod[];
+}
+
+export interface ClassConstructor {
+  parameters: FunctionParameter[];
+  body: Stmt[];
+  span: Span;
+}
+
+export interface ClassMethod {
+  visibility: Visibility;
+  name: string;
+  parameters: FunctionParameter[];
+  returnType?: TypeAnnotation;
+  body: Stmt[];
+  span: Span;
+}
+
+/**
+ * Field creation inside tegura: `rusange _.izina = expr`
+ */
+export interface FieldInitStatement extends Stmt {
+  kind: 'FieldInitStatement';
+  visibility: Visibility;
+  name: string;
+  value: Expr;
+}
+
+/**
+ * Instantiate a class: `rema ClassName(args)`
+ */
+export interface RemaExpr extends Expr {
+  kind: 'RemaExpr';
+  classExpr: Expr;
+  args: Expr[];
 }
 
 /**
@@ -311,6 +362,40 @@ export function mkTypeAlias(
   span: Span,
 ): TypeAliasDeclaration {
   return { kind: 'TypeAliasDeclaration', name, type, span };
+}
+
+export function mkClassDecl(
+  name: string,
+  parentName: string | undefined,
+  ctor: ClassConstructor | undefined,
+  methods: ClassMethod[],
+  span: Span,
+): ClassDeclaration {
+  return {
+    kind: 'ClassDeclaration',
+    name,
+    parentName,
+    constructor: ctor,
+    methods,
+    span,
+  };
+}
+
+export function mkFieldInit(
+  visibility: Visibility,
+  name: string,
+  value: Expr,
+  span: Span,
+): FieldInitStatement {
+  return { kind: 'FieldInitStatement', visibility, name, value, span };
+}
+
+export function mkRema(
+  classExpr: Expr,
+  args: Expr[],
+  span: Span,
+): RemaExpr {
+  return { kind: 'RemaExpr', classExpr, args, span };
 }
 
 export function mkNamedType(name: string, span: Span): NamedType {

--- a/src/parser/parser.ts
+++ b/src/parser/parser.ts
@@ -8,19 +8,24 @@ import TokenType from '../lexer/tokens';
 import { KinError, createKinError } from '../lib/errors';
 import { Span, emptySpan, mergeSpans } from '../lib/span';
 import {
+  ClassConstructor,
+  ClassMethod,
   Expr,
   FunctionParameter,
   Program,
   Stmt,
   TypeAnnotation,
   TypeNode,
+  Visibility,
   mkArray,
   mkAssign,
   mkBinary,
   mkBreak,
   mkCall,
+  mkClassDecl,
   mkConditional,
   mkContinue,
+  mkFieldInit,
   mkFunction,
   mkFunctionParam,
   mkIdent,
@@ -33,6 +38,7 @@ import {
   mkPickType,
   mkProgram,
   mkProperty,
+  mkRema,
   mkReturn,
   mkString,
   mkTypeAlias,
@@ -204,6 +210,7 @@ export default class Parser {
         t === TokenType.GERERANYA ||
         t === TokenType.TANGA ||
         t === TokenType.UBWOKO ||
+        t === TokenType.IMITERERE ||
         t === TokenType.CLOSE_CURLY_BRACES ||
         t === TokenType.HAGARARA ||
         t === TokenType.KOMEZA
@@ -220,7 +227,7 @@ export default class Parser {
       case TokenType.NTAHINDUKA:
         return this.parse_var_declaration();
       case TokenType.UBWOKO:
-        // `ubwoko Name = Type` is a type alias. `ubwoko(x)` / bare use is an expression.
+        // `ubwoko Name = Type` is a type alias. Otherwise typeof prefix expression.
         if (
           this.peek(1).type === TokenType.IDENTIFIER &&
           this.peek(2).type === TokenType.EQUAL
@@ -228,6 +235,8 @@ export default class Parser {
           return this.parse_type_alias_declaration();
         }
         return this.parse_expr();
+      case TokenType.IMITERERE:
+        return this.parse_class_declaration();
       case TokenType.NIBA:
         return this.parse_if_statement();
       case TokenType.GERERANYA:
@@ -242,6 +251,16 @@ export default class Parser {
         return this.parse_function_declaration();
       case TokenType.TANGA:
         return this.parse_return_expr();
+      // Field init statements only appear inside tegura; handled by parse_class.
+      // Visibility at top level is a syntax error.
+      case TokenType.RUSANGE:
+      case TokenType.BWITE:
+        return this.fail(
+          'K001',
+          tokenSpan(this.at()),
+          { lexeme: this.at().lexeme },
+          `Unexpected token ${this.at().lexeme}`,
+        );
       default:
         return this.parse_expr();
     }
@@ -583,7 +602,7 @@ export default class Parser {
   }
 
   /**
-   * Primary atoms: identifiers, literals, grouping, unary ! / -.
+   * Primary atoms: identifiers, literals, grouping, unary ! / - / ubwoko.
    * Array and object literals also live here so they can take postfix
    * member / call chains: [1,2,3][0], {a:1}.a
    */
@@ -593,12 +612,6 @@ export default class Parser {
       case TokenType.IDENTIFIER: {
         const tok = this.eat();
         return mkIdent(tok.lexeme, tokenSpan(tok));
-      }
-      // `ubwoko` is a keyword for type aliases, but remains a call-able name
-      // in expressions: ubwoko(x) / ubwoko x (if used as bare identifier).
-      case TokenType.UBWOKO: {
-        const tok = this.eat();
-        return mkIdent('ubwoko', tokenSpan(tok));
       }
       case TokenType.INTEGER:
       case TokenType.FLOAT: {
@@ -620,9 +633,11 @@ export default class Parser {
       case TokenType.OPEN_CURLY_BRACES:
         return this.parse_object_literal();
       case TokenType.NEGATION:
-        return this.parse_unary_expr();
       case TokenType.MINUS:
         return this.parse_unary_expr();
+      // Prefix typeof: ubwoko x / ubwoko(x) — tighter than every binary op.
+      case TokenType.UBWOKO:
+        return this.parse_ubwoko_expr();
       default:
         return this.fail(
           'K001',
@@ -638,6 +653,20 @@ export default class Parser {
     const operand = this.parse_primary_expr();
     return mkUnary(
       opTok.lexeme,
+      operand,
+      mergeSpans(tokenSpan(opTok), operand.span),
+    );
+  }
+
+  /**
+   * `ubwoko` prefix operator. Operand is a call/member expression so that
+   * `ubwoko x == y` is `(ubwoko x) == y` and `ubwoko(x)` works via grouping.
+   */
+  private parse_ubwoko_expr(): Expr {
+    const opTok = this.eat(); // ubwoko
+    const operand = this.parse_call_member_expr();
+    return mkUnary(
+      'ubwoko',
       operand,
       mergeSpans(tokenSpan(opTok), operand.span),
     );
@@ -707,7 +736,16 @@ export default class Parser {
     return left;
   }
 
+  /**
+   * `rema Class(args)` then optional member/call chain:
+   * `rema Umuntu("K", 20).kwibwira()`  =>  ((rema …).kwibwira)()
+   * rema is tighter than binary ops and produces a value that accepts members.
+   */
   private parse_call_member_expr(): Expr {
+    if (this.at().type == TokenType.REMA) {
+      return this.parse_rema_expr();
+    }
+
     const member = this.parse_member_expr();
 
     if (this.at().type == TokenType.OPEN_PARANTHESES) {
@@ -715,6 +753,70 @@ export default class Parser {
     }
 
     return member;
+  }
+
+  private parse_rema_expr(): Expr {
+    const startTok = this.eat(); // rema
+    // Class expression is a member chain (usually a bare identifier).
+    const classExpr = this.parse_member_expr();
+    if (this.at().type != TokenType.OPEN_PARANTHESES) {
+      this.fail(
+        'K002',
+        tokenSpan(this.at()),
+        { expected: '(', lexeme: this.at().lexeme },
+        `Expected '(' after rema class expression, found ${this.at().lexeme}`,
+      );
+    }
+    const args = this.parse_args();
+    const endTok = this.tokens[this.pos - 1];
+    let expr: Expr = mkRema(
+      classExpr,
+      args,
+      mergeSpans(tokenSpan(startTok), tokenSpan(endTok)),
+    );
+
+    // Postfix: .method / [index] / ()
+    while (
+      this.at().type == TokenType.DOT ||
+      this.at().type == TokenType.OPEN_BRACKET ||
+      this.at().type == TokenType.OPEN_PARANTHESES
+    ) {
+      if (this.at().type == TokenType.OPEN_PARANTHESES) {
+        expr = this.parse_call_expr(expr);
+      } else {
+        // One member suffix then loop.
+        const operator = this.eat();
+        let property: Expr;
+        let computed: boolean;
+        let endSpan: Span;
+        if (operator.type == TokenType.DOT) {
+          computed = false;
+          property = this.parse_primary_expr();
+          if (property.kind !== 'Identifier') {
+            this.fail(
+              'K021',
+              property.span,
+              {},
+              'Dot operator requires an identifier on the right-hand side',
+            );
+          }
+          endSpan = property.span;
+        } else {
+          computed = true;
+          property = this.parse_expr();
+          const close = this.expect(TokenType.CLOSE_BRACKET, ']');
+          endSpan = tokenSpan(close);
+        }
+        expr = mkMember(
+          expr,
+          property,
+          computed,
+          mergeSpans(expr.span, endSpan),
+        );
+      }
+    }
+
+    return expr;
   }
 
   private parse_call_expr(caller: Expr): Expr {
@@ -882,7 +984,7 @@ export default class Parser {
 
     const params = this.parse_function_params();
 
-    // Optional return type: ): number {
+    // Optional return type: ): umubare {
     let returnType: TypeAnnotation | undefined;
     if (this.at().type == TokenType.COLON) {
       returnType = this.parse_type_annotation();
@@ -907,6 +1009,154 @@ export default class Parser {
       mergeSpans(tokenSpan(startTok), endSpan),
       returnType,
     );
+  }
+
+  /**
+   * `imiterere Name ikomoka Parent? { tegura… methods… }`
+   */
+  private parse_class_declaration(): Stmt {
+    const startTok = this.eat(); // imiterere
+    const nameTok = this.expect(TokenType.IDENTIFIER, 'class name');
+    const name = nameTok.lexeme;
+
+    let parentName: string | undefined;
+    if (this.at().type == TokenType.IKOMOKA) {
+      this.eat();
+      const parentTok = this.expect(TokenType.IDENTIFIER, 'parent class name');
+      parentName = parentTok.lexeme;
+    }
+
+    this.expect(TokenType.OPEN_CURLY_BRACES, '{');
+
+    let ctor: ClassConstructor | undefined;
+    const methods: ClassMethod[] = [];
+
+    while (this.not_eof() && this.at().type != TokenType.CLOSE_CURLY_BRACES) {
+      if (this.at().type == TokenType.TEGURA) {
+        if (ctor) {
+          this.fail(
+            'K037',
+            tokenSpan(this.at()),
+            {},
+            'Class already has a tegura constructor',
+          );
+        }
+        ctor = this.parse_class_constructor();
+        continue;
+      }
+
+      if (
+        this.at().type == TokenType.RUSANGE ||
+        this.at().type == TokenType.BWITE
+      ) {
+        const visTok = this.eat();
+        const visibility: Visibility =
+          visTok.type == TokenType.RUSANGE ? 'rusange' : 'bwite';
+        methods.push(this.parse_class_method(visibility, tokenSpan(visTok)));
+        continue;
+      }
+
+      this.fail(
+        'K001',
+        tokenSpan(this.at()),
+        { lexeme: this.at().lexeme },
+        `Unexpected token ${this.at().lexeme} in class body`,
+      );
+    }
+
+    const endTok = this.expect(TokenType.CLOSE_CURLY_BRACES, '}');
+    return mkClassDecl(
+      name,
+      parentName,
+      ctor,
+      methods,
+      mergeSpans(tokenSpan(startTok), tokenSpan(endTok)),
+    );
+  }
+
+  private parse_class_constructor(): ClassConstructor {
+    const startTok = this.eat(); // tegura
+    const params = this.parse_function_params();
+    this.expect(TokenType.OPEN_CURLY_BRACES, '{');
+    const body: Stmt[] = [];
+    while (this.not_eof() && this.at().type != TokenType.CLOSE_CURLY_BRACES) {
+      body.push(this.parse_constructor_stmt());
+    }
+    const endTok = this.expect(TokenType.CLOSE_CURLY_BRACES, '}');
+    return {
+      parameters: params,
+      body,
+      span: mergeSpans(tokenSpan(startTok), tokenSpan(endTok)),
+    };
+  }
+
+  /**
+   * Inside tegura: field inits `rusange _.name = expr` / `bwite _.name = expr`,
+   * or ordinary statements.
+   */
+  private parse_constructor_stmt(): Stmt {
+    if (
+      this.at().type == TokenType.RUSANGE ||
+      this.at().type == TokenType.BWITE
+    ) {
+      const visTok = this.eat();
+      const visibility: Visibility =
+        visTok.type == TokenType.RUSANGE ? 'rusange' : 'bwite';
+
+      // Expect _.fieldName = expr
+      this.expect(TokenType.IDENTIFIER, '_');
+      const under = this.tokens[this.pos - 1];
+      if (under.lexeme !== '_') {
+        this.fail(
+          'K038',
+          tokenSpan(under),
+          {},
+          'Field initialization must use _.<name>',
+        );
+      }
+      this.expect(TokenType.DOT, '.');
+      const nameTok = this.expect(TokenType.IDENTIFIER, 'field name');
+      this.expect(TokenType.EQUAL, '=');
+      const value = this.parse_expr();
+      return mkFieldInit(
+        visibility,
+        nameTok.lexeme,
+        value,
+        mergeSpans(tokenSpan(visTok), value.span),
+      );
+    }
+    return this.parse_stmt();
+  }
+
+  private parse_class_method(
+    visibility: Visibility,
+    visSpan: Span,
+  ): ClassMethod {
+    this.expect(TokenType.POROGARAMU_NTOYA, 'porogaramu_ntoya');
+    const nameTok = this.expect(TokenType.IDENTIFIER, 'method name');
+    const params = this.parse_function_params();
+    let returnType: TypeAnnotation | undefined;
+    if (this.at().type == TokenType.COLON) {
+      returnType = this.parse_type_annotation();
+    }
+    const savedLoopDepth = this.loopDepth;
+    this.loopDepth = 0;
+    let body: Stmt[];
+    try {
+      body = this.parse_block_statement();
+    } finally {
+      this.loopDepth = savedLoopDepth;
+    }
+    const endSpan =
+      body.length > 0 ? body[body.length - 1].span : tokenSpan(nameTok);
+    return {
+      visibility,
+      name: nameTok.lexeme,
+      parameters: params,
+      returnType,
+      body,
+      span: mergeSpans(visSpan, endSpan),
+    };
   }
 
   /**

--- a/src/runtime/environment.ts
+++ b/src/runtime/environment.ts
@@ -4,12 +4,16 @@
  *    in current scope and other questions like this are solved by Kin's Environment       *
  *******************************************************************************************/
 
-import { Interpreter } from '..';
 import { Identifier, MemberExpr } from '../parser/ast';
 import { createKinError } from '../lib/errors';
 import { Span } from '../lib/span';
+import { Interpreter } from './interpreter';
 import {
   ArrayVal,
+  BoundMethodVal,
+  ClassMethodDef,
+  ClassVal,
+  InstanceVal,
   MK_NATIVE_FN,
   MK_NULL,
   NumberVal,
@@ -18,11 +22,21 @@ import {
   StringVal,
   typeName,
 } from './values';
-import { lookupMethod } from './methods';
+import { lookupMethod as lookupBuiltinMethod } from './methods';
 import {
   assertValueMatchesType,
   ResolvedType,
 } from './types';
+
+/**
+ * Active method / constructor frame. Stored on Interpreter's call stack
+ * (not Environment), so freestanding callbacks cannot retain private access.
+ */
+export interface MethodContext {
+  declaringClass: ClassVal;
+  instance: InstanceVal;
+  isConstructor: boolean;
+}
 
 export default class Environment {
   private parent?: Environment;
@@ -39,6 +53,10 @@ export default class Environment {
     this.constants = new Set();
     this.variableTypes = new Map();
     this.typeAliases = new Map();
+  }
+
+  public getMethodContext(): MethodContext | undefined {
+    return Interpreter.getMethodContext();
   }
 
   public declareVar(
@@ -104,7 +122,6 @@ export default class Environment {
         message: `Type '${name}' is already defined`,
       });
     }
-    // Shadowing a value name is fine; types live in a separate namespace.
     this.typeAliases.set(name, type);
   }
 
@@ -116,18 +133,27 @@ export default class Environment {
     return undefined;
   }
 
-  public lookupMember(expr: MemberExpr): RuntimeVal {
-    const { container, key, isArray } = this.resolveMemberTarget(expr);
+  /**
+   * Resolve a class type by name from values (imiterere bindings).
+   * Used so `reka x: Umuntu = …` can check instance class.
+   */
+  public lookupClass(name: string): ClassVal | undefined {
+    try {
+      const v = this.lookupVar(name);
+      if (v.type === 'class') return v as ClassVal;
+    } catch {
+      // not found
+    }
+    return undefined;
+  }
 
-    if (isArray) {
+  public lookupMember(expr: MemberExpr): RuntimeVal {
+    const { container, key, kind } = this.resolveMemberTarget(expr);
+
+    if (kind === 'array') {
       const arr = container as ArrayVal;
-      // Method name via dot: arr.ingano -> native method wrapper is handled
-      // by eval_member_expr when the next node is a call. For bare property
-      // read of a method name we return a bound-style native later; for
-      // numeric index we index the array.
       if (!expr.computed) {
-        // Dot access on array: only methods make sense; missing -> null.
-        const method = lookupMethod(arr, key);
+        const method = lookupBuiltinMethod(arr, key);
         if (method) {
           return MK_NATIVE_FN((args) => method(arr, args, expr.span));
         }
@@ -148,14 +174,18 @@ export default class Environment {
       return arr.elements[index];
     }
 
+    if (kind === 'instance') {
+      return this.lookupInstanceMember(container as InstanceVal, key, expr);
+    }
+
     const obj = container as ObjectVal;
     return obj.properties.get(key) ?? MK_NULL();
   }
 
   public assignMember(expr: MemberExpr, value: RuntimeVal): RuntimeVal {
-    const { container, key, isArray } = this.resolveMemberTarget(expr);
+    const { container, key, kind } = this.resolveMemberTarget(expr);
 
-    if (isArray) {
+    if (kind === 'array') {
       const arr = container as ArrayVal;
       const index = Number(key);
       if (!Number.isInteger(index) || index < 0) {
@@ -165,7 +195,6 @@ export default class Environment {
           message: `Array index ${key} is out of range (length ${arr.elements.length})`,
         });
       }
-      // Allow extending by exactly one past the end (like push via index).
       if (index > arr.elements.length) {
         throw createKinError('K016', {
           span: expr.span,
@@ -181,6 +210,15 @@ export default class Environment {
       return value;
     }
 
+    if (kind === 'instance') {
+      return this.assignInstanceMember(
+        container as InstanceVal,
+        key,
+        value,
+        expr,
+      );
+    }
+
     const obj = container as ObjectVal;
     obj.properties.set(key, value);
     return value;
@@ -194,14 +232,99 @@ export default class Environment {
       : this.assignMember(expr, value);
   }
 
+  private lookupInstanceMember(
+    inst: InstanceVal,
+    key: string,
+    expr: MemberExpr,
+  ): RuntimeVal {
+    // Methods shadow fields of the same name.
+    const method = findMethod(inst.klass, key);
+    if (method) {
+      this.assertMethodAccess(method, expr.span);
+      return {
+        type: 'bound-method',
+        receiver: inst,
+        method,
+      } as BoundMethodVal;
+    }
+
+    if (inst.fields.has(key)) {
+      this.assertFieldAccess(inst, key, expr.span);
+      return inst.fields.get(key)!;
+    }
+
+    return MK_NULL();
+  }
+
+  private assignInstanceMember(
+    inst: InstanceVal,
+    key: string,
+    value: RuntimeVal,
+    expr: MemberExpr,
+  ): RuntimeVal {
+    // Cannot assign to methods.
+    if (findMethod(inst.klass, key)) {
+      throw createKinError('K039', {
+        span: expr.span,
+        params: { name: key },
+        message: `Cannot assign to method '${key}'`,
+      });
+    }
+
+    if (!inst.fields.has(key)) {
+      throw createKinError('K040', {
+        span: expr.span,
+        params: { name: key, klass: inst.klass.name },
+        message: `Field '${key}' does not exist on ${inst.klass.name}; fields are created only in tegura`,
+      });
+    }
+
+    this.assertFieldAccess(inst, key, expr.span);
+    inst.fields.set(key, value);
+    return value;
+  }
+
+  private canAccessPrivate(owner: ClassVal): boolean {
+    const ctx = this.getMethodContext();
+    return ctx !== undefined && ctx.declaringClass === owner;
+  }
+
+  private assertFieldAccess(
+    inst: InstanceVal,
+    key: string,
+    span?: Span,
+  ): void {
+    const vis = inst.fieldVisibility.get(key);
+    if (vis !== 'bwite') return;
+    const owner = inst.fieldOwner.get(key);
+    if (!owner || !this.canAccessPrivate(owner)) {
+      throw createKinError('K041', {
+        span,
+        params: { name: key },
+        message: `Cannot access private field '${key}'`,
+      });
+    }
+  }
+
+  private assertMethodAccess(method: ClassMethodDef, span?: Span): void {
+    if (method.visibility !== 'bwite') return;
+    if (!this.canAccessPrivate(method.ownerClass)) {
+      throw createKinError('K041', {
+        span,
+        params: { name: method.name },
+        message: `Cannot access private method '${method.name}'`,
+      });
+    }
+  }
+
   /**
    * Walks a member expression (e.g. `arr[0][1]` or `obj.a.b.c`) down to the
    * container the leaf property belongs to.
    */
   private resolveMemberTarget(expr: MemberExpr): {
-    container: ObjectVal | ArrayVal;
+    container: ObjectVal | ArrayVal | InstanceVal;
     key: string;
-    isArray: boolean;
+    kind: 'object' | 'array' | 'instance';
   } {
     let obj: RuntimeVal;
 
@@ -216,25 +339,24 @@ export default class Environment {
 
     const key = this.resolveMemberKey(expr);
 
-    // Method lookup on string / array is handled for computed=false by
-    // returning a bound native; still need a container for indexing.
     if (obj && obj.type === 'array') {
-      return { container: obj as ArrayVal, key, isArray: true };
+      return { container: obj as ArrayVal, key, kind: 'array' };
+    }
+
+    if (obj && obj.type === 'instance') {
+      return { container: obj as InstanceVal, key, kind: 'instance' };
     }
 
     if (obj && obj.type === 'string' && !expr.computed) {
-      // String methods: return a synthetic object path via lookupMember.
-      // Handled specially: treat as array-like method table.
-      const method = lookupMethod(obj, key);
+      const method = lookupBuiltinMethod(obj, key);
       if (method) {
-        // Surface the method via a temporary object so lookupMember works.
         const fake: ObjectVal = {
           type: 'object',
           properties: new Map([
             [key, MK_NATIVE_FN((args) => method(obj, args, expr.span))],
           ]),
         };
-        return { container: fake, key, isArray: false };
+        return { container: fake, key, kind: 'object' };
       }
     }
 
@@ -249,7 +371,7 @@ export default class Environment {
       });
     }
 
-    return { container: obj as ObjectVal, key, isArray: false };
+    return { container: obj as ObjectVal, key, kind: 'object' };
   }
 
   private resolveMemberKey(expr: MemberExpr): string {
@@ -285,4 +407,33 @@ export default class Environment {
 
     return this.parent.resolve(varname);
   }
+}
+
+/** Method lookup: own class first, then walk parents. */
+export function findMethod(
+  klass: ClassVal,
+  name: string,
+): ClassMethodDef | undefined {
+  if (klass.methods.has(name)) return klass.methods.get(name);
+  if (klass.parent) return findMethod(klass.parent, name);
+  return undefined;
+}
+
+/** Resolve constructor: own tegura, else inherited, else empty. */
+export function findConstructor(klass: ClassVal): {
+  params: string[];
+  paramTypes?: (import('./types').ResolvedType | undefined)[];
+  body: import('../parser/ast').Stmt[];
+  owner: ClassVal;
+} {
+  if (klass.hasConstructor) {
+    return {
+      params: klass.constructorParams,
+      paramTypes: klass.constructorParamTypes,
+      body: klass.constructorBody,
+      owner: klass,
+    };
+  }
+  if (klass.parent) return findConstructor(klass.parent);
+  return { params: [], body: [], owner: klass };
 }

--- a/src/runtime/eval/expressions.ts
+++ b/src/runtime/eval/expressions.ts
@@ -5,6 +5,7 @@
 
 import {
   BooleanVal,
+  BoundMethodVal,
   FunctionValue,
   MK_ARRAY,
   MK_BOOL,
@@ -17,6 +18,7 @@ import {
   RuntimeVal,
   StringVal,
   typeName,
+  ubwokoOf,
   valuesEqual,
 } from '../values';
 import {
@@ -29,6 +31,7 @@ import {
   CallExpr,
   UnaryExpr,
   ReturnExpr,
+  RemaExpr,
 } from '../../parser/ast';
 
 import Environment from '../environment';
@@ -37,6 +40,7 @@ import { createKinError } from '../../lib/errors';
 import { BreakSignal, ContinueSignal, ReturnSignal } from '../signals';
 import { Span } from '../../lib/span';
 import { assertValueMatchesType } from '../types';
+import { call_bound_method, eval_rema } from '../oop';
 
 type BinOp = (lhs: RuntimeVal, rhs: RuntimeVal, span?: Span) => RuntimeVal;
 
@@ -116,6 +120,9 @@ export default class EvalExpr {
           });
         }
         return MK_NUMBER(-(operand as NumberVal).value);
+      case 'ubwoko':
+        // Prefix typeof: returns TypeVal or ClassVal (for instances).
+        return ubwokoOf(operand);
       default:
         throw createKinError('K024', {
           span: node.span,
@@ -123,6 +130,10 @@ export default class EvalExpr {
           message: `Unsupported unary operator ${node.operator}`,
         });
     }
+  }
+
+  public static eval_rema_expr(node: RemaExpr, env: Environment): RuntimeVal {
+    return eval_rema(node, env);
   }
 
   public static eval_assignment(
@@ -177,6 +188,10 @@ export default class EvalExpr {
       return (fn as NativeFnValue).call(args, env);
     }
 
+    if (fn.type == 'bound-method') {
+      return call_bound_method(fn as BoundMethodVal, args, expr.span);
+    }
+
     if (fn.type == 'fn') {
       const func = fn as FunctionValue;
       const scope = new Environment(func.declarationEnv);
@@ -204,32 +219,38 @@ export default class EvalExpr {
         );
       }
 
+      // Freestanding functions must not inherit caller's private privileges.
+      const savedContexts = Interpreter.suspendMethodContexts();
       try {
-        for (const stmt of func.body) {
-          Interpreter.evaluate(stmt, scope);
-        }
-      } catch (e) {
-        if (e instanceof ReturnSignal) {
-          if (func.returnType) {
-            assertValueMatchesType(e.value, func.returnType, expr.span);
+        try {
+          for (const stmt of func.body) {
+            Interpreter.evaluate(stmt, scope);
           }
-          return e.value;
+        } catch (e) {
+          if (e instanceof ReturnSignal) {
+            if (func.returnType) {
+              assertValueMatchesType(e.value, func.returnType, expr.span);
+            }
+            return e.value;
+          }
+          if (e instanceof BreakSignal) {
+            throw createKinError('K019', {
+              span: expr.span,
+              params: { name: 'hagarara' },
+              message: 'hagarara cannot be used across a function boundary',
+            });
+          }
+          if (e instanceof ContinueSignal) {
+            throw createKinError('K019', {
+              span: expr.span,
+              params: { name: 'komeza' },
+              message: 'komeza cannot be used across a function boundary',
+            });
+          }
+          throw e;
         }
-        if (e instanceof BreakSignal) {
-          throw createKinError('K019', {
-            span: expr.span,
-            params: { name: 'hagarara' },
-            message: 'hagarara cannot be used across a function boundary',
-          });
-        }
-        if (e instanceof ContinueSignal) {
-          throw createKinError('K019', {
-            span: expr.span,
-            params: { name: 'komeza' },
-            message: 'komeza cannot be used across a function boundary',
-          });
-        }
-        throw e;
+      } finally {
+        Interpreter.restoreMethodContexts(savedContexts);
       }
 
       // Implicit null return when function has a return type annotation.

--- a/src/runtime/eval/statements.ts
+++ b/src/runtime/eval/statements.ts
@@ -5,8 +5,10 @@
 
 import {
   BreakStatement,
+  ClassDeclaration,
   ConditionalStmt,
   ContinueStatement,
+  FieldInitStatement,
   FunctionDeclaration,
   LoopStatement,
   Program,
@@ -27,6 +29,7 @@ import {
   isReturnSignal,
 } from '../signals';
 import { resolveAnnotation, resolveTypeNode } from '../types';
+import { eval_class_declaration, eval_field_init } from '../oop';
 
 export default class EvalStmt {
   public static eval_program(program: Program, env: Environment): RuntimeVal {
@@ -65,6 +68,20 @@ export default class EvalStmt {
     const resolved = resolveTypeNode(declaration.type, env);
     env.declareType(declaration.name, resolved);
     return MK_NULL();
+  }
+
+  public static eval_class_declaration(
+    declaration: ClassDeclaration,
+    env: Environment,
+  ): RuntimeVal {
+    return eval_class_declaration(declaration, env);
+  }
+
+  public static eval_field_init(
+    declaration: FieldInitStatement,
+    env: Environment,
+  ): RuntimeVal {
+    return eval_field_init(declaration, env);
   }
 
   public static eval_function_declaration(

--- a/src/runtime/globals.ts
+++ b/src/runtime/globals.ts
@@ -37,6 +37,9 @@ export function createGlobalEnv(filename: string): Environment {
   env.declareVar('KIN_AMAGAMBO', createKinAmagambo(), true);
   env.declareVar('KIN_IGIHE', createKinIgihe(), true);
   env.declareVar('KIN_URUTONDE', createKinUrutonde(), true);
+  // Registered for the JS API / env shape. In source, `ubwoko` is a keyword
+  // (prefix operator + type-alias). The global remains callable if obtained
+  // without the keyword path.
   env.declareVar('ubwoko', ubwoko, true);
   env.declareVar('KIN_INYANDIKO', createKinInyandiko(), true);
 

--- a/src/runtime/in-built/types.ts
+++ b/src/runtime/in-built/types.ts
@@ -1,9 +1,13 @@
-import { MK_STRING, NativeFnValue, typeName } from '../values';
+import { NativeFnValue, ubwokoOf } from '../values';
 import { defineNative } from '../native';
 
-/** ubwoko — runtime type name of a value (urutonde for arrays). */
+/**
+ * ubwoko — returns a type value (TypeVal / ClassVal for instances).
+ * Source code usually uses the keyword form: `ubwoko x` / `ubwoko(x)`.
+ * This native remains for the env API and identity comparisons.
+ */
 export const ubwoko: NativeFnValue = defineNative({
   name: 'ubwoko',
   minArgs: 1,
-  fn: (args) => MK_STRING(typeName(args[0])),
+  fn: (args) => ubwokoOf(args[0]),
 });

--- a/src/runtime/interpreter.ts
+++ b/src/runtime/interpreter.ts
@@ -9,8 +9,10 @@ import {
   AssignmentExpr,
   BinaryExpr,
   BreakStatement,
+  ClassDeclaration,
   ContinueStatement,
   CallExpr,
+  FieldInitStatement,
   LoopStatement,
   FunctionDeclaration,
   Identifier,
@@ -18,6 +20,7 @@ import {
   NumericLiteral,
   ObjectLiteral,
   Program,
+  RemaExpr,
   Stmt,
   StringLiteral,
   ConditionalStmt,
@@ -27,7 +30,7 @@ import {
   ReturnExpr,
 } from '../parser/ast';
 
-import Environment from './environment';
+import Environment, { MethodContext } from './environment';
 import EvalExpr from './eval/expressions';
 import EvalStmt from './eval/statements';
 import { KinError, createKinError } from '../lib/errors';
@@ -36,6 +39,36 @@ import { Span } from '../lib/span';
 export class Interpreter {
   /** Span of the node currently being evaluated (for runtime errors). */
   public static currentSpan: Span | undefined;
+
+  /**
+   * Active tegura / method frames. Push on enter, pop on exit — never sticky
+   * on Environment, so nested freestanding functions cannot keep private access.
+   */
+  private static methodContextStack: MethodContext[] = [];
+
+  public static pushMethodContext(ctx: MethodContext): void {
+    this.methodContextStack.push(ctx);
+  }
+
+  public static popMethodContext(): void {
+    this.methodContextStack.pop();
+  }
+
+  public static getMethodContext(): MethodContext | undefined {
+    if (this.methodContextStack.length === 0) return undefined;
+    return this.methodContextStack[this.methodContextStack.length - 1];
+  }
+
+  /** Clear privileges for freestanding porogaramu_ntoya calls; restore in finally. */
+  public static suspendMethodContexts(): MethodContext[] {
+    const saved = this.methodContextStack;
+    this.methodContextStack = [];
+    return saved;
+  }
+
+  public static restoreMethodContexts(saved: MethodContext[]): void {
+    this.methodContextStack = saved;
+  }
 
   public static evaluate(astNode: Stmt, env: Environment): RuntimeVal {
     const previous = this.currentSpan;
@@ -68,6 +101,8 @@ export class Interpreter {
           return EvalExpr.eval_binary_expr(astNode as BinaryExpr, env);
         case 'UnaryExpr':
           return EvalExpr.eval_unary_expr(astNode as UnaryExpr, env);
+        case 'RemaExpr':
+          return EvalExpr.eval_rema_expr(astNode as RemaExpr, env);
         case 'MemberExpression':
           return EvalExpr.eval_member_expr(
             env,
@@ -93,6 +128,16 @@ export class Interpreter {
         case 'TypeAliasDeclaration':
           return EvalStmt.eval_type_alias(
             astNode as TypeAliasDeclaration,
+            env,
+          );
+        case 'ClassDeclaration':
+          return EvalStmt.eval_class_declaration(
+            astNode as ClassDeclaration,
+            env,
+          );
+        case 'FieldInitStatement':
+          return EvalStmt.eval_field_init(
+            astNode as FieldInitStatement,
             env,
           );
         case 'FunctionDeclaration':

--- a/src/runtime/oop.ts
+++ b/src/runtime/oop.ts
@@ -1,0 +1,277 @@
+/***********************************************************************
+ *                         OOP evaluation helpers                      *
+ *   imiterere / tegura / rema / methods / field init / visibility     *
+ ***********************************************************************/
+
+import {
+  ClassDeclaration,
+  FieldInitStatement,
+  RemaExpr,
+} from '../parser/ast';
+import { createKinError } from '../lib/errors';
+import Environment, { findConstructor } from './environment';
+import { Interpreter } from './interpreter';
+import { assertValueMatchesType, resolveAnnotation } from './types';
+import {
+  BoundMethodVal,
+  ClassMethodDef,
+  ClassVal,
+  InstanceVal,
+  MK_NULL,
+  RuntimeVal,
+} from './values';
+import { BreakSignal, ContinueSignal, ReturnSignal } from './signals';
+
+export function eval_class_declaration(
+  decl: ClassDeclaration,
+  env: Environment,
+): RuntimeVal {
+  let parent: ClassVal | undefined;
+  if (decl.parentName) {
+    const p = env.lookupVar(decl.parentName);
+    if (p.type !== 'class') {
+      throw createKinError('K042', {
+        span: decl.span,
+        params: { name: decl.parentName },
+        message: `'${decl.parentName}' is not a class (imiterere)`,
+      });
+    }
+    parent = p as ClassVal;
+  }
+
+  const klass: ClassVal = {
+    type: 'class',
+    name: decl.name,
+    parent,
+    hasConstructor: !!decl.constructor,
+    constructorParams: [],
+    constructorBody: [],
+    methods: new Map(),
+    declarationEnv: env,
+  };
+
+  if (decl.constructor) {
+    klass.constructorParams = decl.constructor.parameters.map((p) => p.name);
+    klass.constructorParamTypes = decl.constructor.parameters.map((p) =>
+      p.typeAnnotation ? resolveAnnotation(p.typeAnnotation, env) : undefined,
+    );
+    klass.constructorBody = decl.constructor.body;
+  }
+
+  for (const m of decl.methods) {
+    if (klass.methods.has(m.name)) {
+      throw createKinError('K043', {
+        span: m.span,
+        params: { name: m.name },
+        message: `Method '${m.name}' is already defined on ${decl.name}`,
+      });
+    }
+    const def: ClassMethodDef = {
+      visibility: m.visibility,
+      name: m.name,
+      parameters: m.parameters.map((p) => p.name),
+      parameterTypes: m.parameters.map((p) =>
+        p.typeAnnotation ? resolveAnnotation(p.typeAnnotation, env) : undefined,
+      ),
+      returnType: m.returnType
+        ? resolveAnnotation(m.returnType, env)
+        : undefined,
+      body: m.body,
+      ownerClass: klass,
+    };
+    klass.methods.set(m.name, def);
+  }
+
+  env.declareVar(decl.name, klass, true);
+  env.declareType(decl.name, {
+    kind: 'class',
+    className: decl.name,
+    classRef: klass,
+  });
+
+  return klass;
+}
+
+export function eval_rema(expr: RemaExpr, env: Environment): RuntimeVal {
+  const classVal = Interpreter.evaluate(expr.classExpr, env);
+  if (classVal.type !== 'class') {
+    throw createKinError('K042', {
+      span: expr.span,
+      params: { name: 'rema' },
+      message: `rema expects a class (imiterere), got ${classVal.type}`,
+    });
+  }
+  const klass = classVal as ClassVal;
+  const args = expr.args.map((a) => Interpreter.evaluate(a, env));
+  const ctor = findConstructor(klass);
+
+  if (args.length !== ctor.params.length) {
+    throw createKinError('K011', {
+      span: expr.span,
+      params: { expected: ctor.params.length, got: args.length },
+      message: `Wrong number of arguments for rema ${klass.name}: expected ${ctor.params.length}, got ${args.length}`,
+    });
+  }
+
+  const instance: InstanceVal = {
+    type: 'instance',
+    klass,
+    fields: new Map(),
+    fieldVisibility: new Map(),
+    fieldOwner: new Map(),
+  };
+
+  const scope = new Environment(ctor.owner.declarationEnv);
+  scope.declareVar('_', instance, true);
+
+  for (let i = 0; i < ctor.params.length; i++) {
+    const pt = ctor.paramTypes?.[i];
+    scope.declareVar(ctor.params[i], args[i], false, pt, expr.span);
+  }
+
+  Interpreter.pushMethodContext({
+    declaringClass: ctor.owner,
+    instance,
+    isConstructor: true,
+  });
+  try {
+    try {
+      for (const stmt of ctor.body) {
+        Interpreter.evaluate(stmt, scope);
+      }
+    } catch (e) {
+      if (e instanceof ReturnSignal) {
+        return instance;
+      }
+      if (e instanceof BreakSignal) {
+        throw createKinError('K019', {
+          span: expr.span,
+          params: { name: 'hagarara' },
+          message: 'hagarara cannot be used across a function boundary',
+        });
+      }
+      if (e instanceof ContinueSignal) {
+        throw createKinError('K019', {
+          span: expr.span,
+          params: { name: 'komeza' },
+          message: 'komeza cannot be used across a function boundary',
+        });
+      }
+      throw e;
+    }
+  } finally {
+    Interpreter.popMethodContext();
+  }
+
+  return instance;
+}
+
+export function eval_field_init(
+  stmt: FieldInitStatement,
+  env: Environment,
+): RuntimeVal {
+  const ctx = Interpreter.getMethodContext();
+  if (!ctx || !ctx.isConstructor) {
+    throw createKinError('K038', {
+      span: stmt.span,
+      message: 'Field initialization is only allowed inside tegura',
+    });
+  }
+
+  const { instance, declaringClass: owner } = ctx;
+
+  if (instance.fields.has(stmt.name)) {
+    throw createKinError('K043', {
+      span: stmt.span,
+      params: { name: stmt.name },
+      message: `Field '${stmt.name}' is already defined`,
+    });
+  }
+
+  const value = Interpreter.evaluate(stmt.value, env);
+  instance.fields.set(stmt.name, value);
+  instance.fieldVisibility.set(stmt.name, stmt.visibility);
+  instance.fieldOwner.set(stmt.name, owner);
+  return value;
+}
+
+export function call_bound_method(
+  bound: BoundMethodVal,
+  args: RuntimeVal[],
+  span?: import('../lib/span').Span,
+): RuntimeVal {
+  const { receiver, method } = bound;
+
+  // Re-check private so a leaked bound method cannot be invoked outside.
+  if (method.visibility === 'bwite') {
+    const ctx = Interpreter.getMethodContext();
+    if (!ctx || ctx.declaringClass !== method.ownerClass) {
+      throw createKinError('K041', {
+        span,
+        params: { name: method.name },
+        message: `Cannot access private method '${method.name}'`,
+      });
+    }
+  }
+
+  if (args.length !== method.parameters.length) {
+    throw createKinError('K011', {
+      span,
+      params: {
+        expected: method.parameters.length,
+        got: args.length,
+      },
+      message: `Wrong number of arguments: expected ${method.parameters.length}, got ${args.length}`,
+    });
+  }
+
+  const scope = new Environment(method.ownerClass.declarationEnv);
+  scope.declareVar('_', receiver, true);
+
+  for (let i = 0; i < method.parameters.length; i++) {
+    const pt = method.parameterTypes?.[i];
+    scope.declareVar(method.parameters[i], args[i], false, pt, span);
+  }
+
+  Interpreter.pushMethodContext({
+    declaringClass: method.ownerClass,
+    instance: receiver,
+    isConstructor: false,
+  });
+  try {
+    try {
+      for (const stmt of method.body) {
+        Interpreter.evaluate(stmt, scope);
+      }
+    } catch (e) {
+      if (e instanceof ReturnSignal) {
+        if (method.returnType) {
+          assertValueMatchesType(e.value, method.returnType, span);
+        }
+        return e.value;
+      }
+      if (e instanceof BreakSignal) {
+        throw createKinError('K019', {
+          span,
+          params: { name: 'hagarara' },
+          message: 'hagarara cannot be used across a function boundary',
+        });
+      }
+      if (e instanceof ContinueSignal) {
+        throw createKinError('K019', {
+          span,
+          params: { name: 'komeza' },
+          message: 'komeza cannot be used across a function boundary',
+        });
+      }
+      throw e;
+    }
+  } finally {
+    Interpreter.popMethodContext();
+  }
+
+  if (method.returnType) {
+    assertValueMatchesType(MK_NULL(), method.returnType, span);
+  }
+  return MK_NULL();
+}

--- a/src/runtime/print.ts
+++ b/src/runtime/print.ts
@@ -11,6 +11,10 @@ import {
   ObjectVal,
   ArrayVal,
   FunctionValue,
+  ClassVal,
+  InstanceVal,
+  TypeVal,
+  BoundMethodVal,
   MK_STRING,
 } from './values';
 
@@ -65,6 +69,25 @@ export function matchType(arg: RuntimeVal): unknown {
         body: fn.body,
         internal: false,
       };
+    }
+    case 'class':
+      // Class value prints the class name.
+      return (arg as ClassVal).name;
+    case 'type-val':
+      // Type value prints its type name.
+      return (arg as TypeVal).name;
+    case 'instance': {
+      // Instance shows class name and public-ish field dump.
+      const inst = arg as InstanceVal;
+      const fields: { [key: string]: unknown } = {};
+      inst.fields.forEach((value, key) => {
+        fields[key] = matchType(value);
+      });
+      return `${inst.klass.name} ${JSON.stringify(fields)}`;
+    }
+    case 'bound-method': {
+      const bm = arg as BoundMethodVal;
+      return `<method ${bm.method.name}>`;
     }
     default:
       return arg;

--- a/src/runtime/types.ts
+++ b/src/runtime/types.ts
@@ -16,6 +16,8 @@ import { createKinError } from '../lib/errors';
 import { Span } from '../lib/span';
 import {
   ArrayVal,
+  ClassVal,
+  InstanceVal,
   ObjectVal,
   RuntimeVal,
   typeName as runtimeValueTypeName,
@@ -44,7 +46,9 @@ const PRIMITIVE_NAMES = new Set([
 export type ResolvedType =
   | { kind: 'primitive'; name: string }
   | { kind: 'object'; properties: Map<string, ResolvedType> }
-  | { kind: 'union'; members: ResolvedType[] };
+  | { kind: 'union'; members: ResolvedType[] }
+  /** Exact class instance type (no inheritance widening). */
+  | { kind: 'class'; className: string; classRef: ClassVal };
 
 // ---------------------------------------------------------------------------
 // Resolution
@@ -111,6 +115,12 @@ function resolveNamedType(node: NamedType, env: Environment): ResolvedType {
   // User-defined type alias
   const alias = env.lookupType(name);
   if (alias) return alias;
+
+  // Class name used as a type (exact instance match).
+  const klass = env.lookupClass(name);
+  if (klass) {
+    return { kind: 'class', className: klass.name, classRef: klass };
+  }
 
   throw createKinError('K033', {
     span: node.span,
@@ -191,8 +201,17 @@ export function valueMatchesType(
     return valueMatchesPrimitive(value, expected.name);
   }
 
+  if (expected.kind === 'class') {
+    // Exact class match only — inheritance does not widen (see types-and-ubwoko).
+    return (
+      value.type === 'instance' &&
+      (value as InstanceVal).klass === expected.classRef
+    );
+  }
+
   // Object type — structural: value must be object and every required
   // property must match. Extra properties are allowed (open structural).
+  // Class instances are NOT plain objects.
   if (value.type !== 'object') return false;
   const obj = value as ObjectVal;
   for (const [key, propType] of expected.properties) {
@@ -242,6 +261,8 @@ export function formatResolvedType(type: ResolvedType): string {
       return primitiveSurfaceName(type.name);
     case 'union':
       return type.members.map(formatResolvedType).join(' | ');
+    case 'class':
+      return type.className;
     case 'object': {
       const parts: string[] = [];
       for (const [key, propType] of type.properties) {

--- a/src/runtime/values.ts
+++ b/src/runtime/values.ts
@@ -3,7 +3,7 @@
  *              Kin's runtime values, responsible of defining Runtime values types             *
  ***********************************************************************************************/
 
-import { Stmt } from '../parser/ast';
+import { Stmt, Visibility } from '../parser/ast';
 import Environment from './environment';
 import type { ResolvedType } from './types';
 
@@ -15,7 +15,11 @@ export type ValueType =
   | 'array'
   | 'native-fn'
   | 'fn'
-  | 'string';
+  | 'string'
+  | 'class'
+  | 'instance'
+  | 'type-val'
+  | 'bound-method';
 
 export interface RuntimeVal {
   type: ValueType;
@@ -71,6 +75,84 @@ export interface NativeFnValue extends RuntimeVal {
   call: FunctionCall;
 }
 
+/** Method definition stored on a class (not a first-class value by itself). */
+export interface ClassMethodDef {
+  visibility: Visibility;
+  name: string;
+  parameters: string[];
+  parameterTypes?: (ResolvedType | undefined)[];
+  returnType?: ResolvedType;
+  body: Stmt[];
+  /** Class that declared this method (for private access). */
+  ownerClass: ClassVal;
+}
+
+/**
+ * Class value bound by `imiterere Name { … }`.
+ * First-class: can be passed around and used with `rema`.
+ */
+export interface ClassVal extends RuntimeVal {
+  type: 'class';
+  name: string;
+  parent?: ClassVal;
+  hasConstructor: boolean;
+  constructorParams: string[];
+  constructorParamTypes?: (ResolvedType | undefined)[];
+  constructorBody: Stmt[];
+  methods: Map<string, ClassMethodDef>;
+  declarationEnv: Environment;
+}
+
+export interface InstanceVal extends RuntimeVal {
+  type: 'instance';
+  klass: ClassVal;
+  fields: Map<string, RuntimeVal>;
+  fieldVisibility: Map<string, Visibility>;
+  /** Which class introduced each field (private checks). */
+  fieldOwner: Map<string, ClassVal>;
+}
+
+/**
+ * Built-in type tag used by the `ubwoko` operator for identity comparisons.
+ * e.g. ubwoko(5) == ubwoko(10)  (same TypeVal singleton).
+ * For instances, ubwoko returns the ClassVal itself instead.
+ */
+export interface TypeVal extends RuntimeVal {
+  type: 'type-val';
+  name: string;
+}
+
+/** Method closed over its receiver: `reka f = keza.kwibwira; f()`. */
+export interface BoundMethodVal extends RuntimeVal {
+  type: 'bound-method';
+  receiver: InstanceVal;
+  method: ClassMethodDef;
+}
+
+// ---------------------------------------------------------------------------
+// Built-in type-value singletons (identity equality for ubwoko)
+// ---------------------------------------------------------------------------
+
+export const TYPE_UMUBARE: TypeVal = { type: 'type-val', name: 'umubare' };
+export const TYPE_IJAMBO: TypeVal = { type: 'type-val', name: 'ijambo' };
+export const TYPE_UKURI: TypeVal = { type: 'type-val', name: 'ukuri' };
+export const TYPE_UBUSA: TypeVal = { type: 'type-val', name: 'ubusa' };
+export const TYPE_URUTONDE: TypeVal = { type: 'type-val', name: 'urutonde' };
+export const TYPE_UBWOKO_IMITERERE: TypeVal = {
+  type: 'type-val',
+  name: 'ubwoko_imiterere',
+};
+/** Shared by user functions and native functions for ubwoko identity. */
+export const TYPE_POROGARAMU_NTOYA: TypeVal = {
+  type: 'type-val',
+  name: 'porogaramu_ntoya',
+};
+/** Shared by all class values: ubwoko Umuntu == ubwoko Umwarimu. */
+export const TYPE_IMITERERE: TypeVal = {
+  type: 'type-val',
+  name: 'imiterere',
+};
+
 export function MK_NATIVE_FN(call: FunctionCall) {
   return { type: 'native-fn', call } as NativeFnValue;
 }
@@ -100,7 +182,40 @@ export function MK_ARRAY(elements: RuntimeVal[] = []) {
 }
 
 /**
- * Human-facing Kinyarwanda type name for `ubwoko()` and error messages.
+ * Type value returned by the `ubwoko` operator (not a string).
+ * Instances return their ClassVal; classes return TYPE_IMITERERE.
+ */
+export function ubwokoOf(value: RuntimeVal): RuntimeVal {
+  switch (value.type) {
+    case 'number':
+      return TYPE_UMUBARE;
+    case 'string':
+      return TYPE_IJAMBO;
+    case 'boolean':
+      return TYPE_UKURI;
+    case 'null':
+      return TYPE_UBUSA;
+    case 'array':
+      return TYPE_URUTONDE;
+    case 'object':
+      return TYPE_UBWOKO_IMITERERE;
+    case 'fn':
+    case 'native-fn':
+    case 'bound-method':
+      return TYPE_POROGARAMU_NTOYA;
+    case 'class':
+      return TYPE_IMITERERE;
+    case 'instance':
+      return (value as InstanceVal).klass;
+    case 'type-val':
+      return value;
+    default:
+      return TYPE_UBUSA;
+  }
+}
+
+/**
+ * Human-facing Kinyarwanda type name for error messages and printing.
  */
 export function typeName(value: RuntimeVal): string {
   switch (value.type) {
@@ -115,11 +230,18 @@ export function typeName(value: RuntimeVal): string {
     case 'array':
       return 'urutonde';
     case 'fn':
+    case 'bound-method':
       return 'porogaramu_ntoya';
     case 'native-fn':
       return '_porogaramu_ntoya';
     case 'null':
       return 'ubusa';
+    case 'class':
+      return 'imiterere';
+    case 'instance':
+      return (value as InstanceVal).klass.name;
+    case 'type-val':
+      return (value as TypeVal).name;
     default:
       return value.type;
   }
@@ -152,7 +274,14 @@ export function valuesEqual(a: RuntimeVal, b: RuntimeVal): boolean {
       return (a as FunctionValue).body === (b as FunctionValue).body;
     case 'native-fn':
       return (a as NativeFnValue).call === (b as NativeFnValue).call;
+    case 'class':
+    case 'instance':
+    case 'type-val':
+    case 'bound-method':
+      // Identity equality (reference).
+      return a === b;
     default:
       return false;
   }
 }
+

--- a/tests/examples.test.ts
+++ b/tests/examples.test.ts
@@ -20,15 +20,28 @@ vi.mock('prompt-sync', () => ({
 }));
 
 const EXAMPLES_DIR = path.join(process.cwd(), 'examples');
+const OOP_DIR = path.join(EXAMPLES_DIR, 'oop');
 
-/** stdin answers for examples that call injiza_amakuru */
+/** stdin answers for examples that call injiza_amakuru (keyed by relative path) */
 const EXAMPLE_INPUTS: Record<string, string[]> = {
   'io.kin': ['hello', 'world'],
   'switch.kin': ['a'],
 };
 
-function runExample(filename: string): void {
-  const filePath = path.join(EXAMPLES_DIR, filename);
+/** Collect .kin files under examples/ and examples/oop/ as relative paths. */
+function listExamplePaths(): string[] {
+  const top = readdirSync(EXAMPLES_DIR)
+    .filter((file) => file.endsWith('.kin'))
+    .sort();
+  const oop = readdirSync(OOP_DIR)
+    .filter((file) => file.endsWith('.kin'))
+    .map((file) => path.join('oop', file))
+    .sort();
+  return [...top, ...oop];
+}
+
+function runExample(relativePath: string): void {
+  const filePath = path.join(EXAMPLES_DIR, relativePath);
   const source = readFileSync(filePath, 'utf-8');
   const parser = new Parser();
   const ast = parser.produceAST(source);
@@ -46,11 +59,9 @@ describe('Example programs (current language implementation)', () => {
     vi.restoreAllMocks();
   });
 
-  const examples = readdirSync(EXAMPLES_DIR)
-    .filter((file) => file.endsWith('.kin'))
-    .sort();
+  const examples = listExamplePaths();
 
-  test('discovers at least the shipped example programs', () => {
+  test('discovers top-level and oop example programs', () => {
     expect(examples.length).toBeGreaterThan(0);
     expect(examples).toEqual(
       expect.arrayContaining([
@@ -61,12 +72,21 @@ describe('Example programs (current language implementation)', () => {
         'loops.kin',
         'objects.kin',
         'switch.kin',
+        'types.kin',
+        'oop/class-basics.kin',
+        'oop/visibility.kin',
+        'oop/inheritance.kin',
+        'oop/instances-and-binding.kin',
+        'oop/types-and-ubwoko.kin',
       ]),
     );
   });
 
-  test.each(examples)('runs %s without throwing', (filename) => {
-    promptAnswers.queue = [...(EXAMPLE_INPUTS[filename] ?? [])];
-    expect(() => runExample(filename)).not.toThrow();
+  test.each(examples)('runs %s without throwing', (relativePath) => {
+    const base = path.basename(relativePath);
+    promptAnswers.queue = [
+      ...(EXAMPLE_INPUTS[relativePath] ?? EXAMPLE_INPUTS[base] ?? []),
+    ];
+    expect(() => runExample(relativePath)).not.toThrow();
   });
 });

--- a/tests/globals.test.ts
+++ b/tests/globals.test.ts
@@ -578,29 +578,41 @@ describe('createGlobalEnv', () => {
   });
 
   describe('ubwoko', () => {
-    test('returns the runtime type name', () => {
-      expect(asString(evaluate('ubwoko(1)').result)).toBe('umubare');
-      expect(asString(evaluate('ubwoko("kin")').result)).toBe('ijambo');
-      expect(asString(evaluate('ubwoko(nibyo)').result)).toBe('ukuri');
-      expect(asString(evaluate('ubwoko(ubusa)').result)).toBe('ubusa');
-      expect(asString(evaluate('ubwoko([1])').result)).toBe('urutonde');
-      expect(asString(evaluate('ubwoko(tangaza_amakuru)').result)).toBe(
-        '_porogaramu_ntoya',
+    test('returns a type value (identity-comparable)', () => {
+      const n = evaluate('ubwoko(1)').result;
+      expect(n.type).toBe('type-val');
+      expect((n as { name: string }).name).toBe('umubare');
+      expect((evaluate('ubwoko("kin")').result as { name: string }).name).toBe(
+        'ijambo',
       );
+      expect((evaluate('ubwoko(nibyo)').result as { name: string }).name).toBe(
+        'ukuri',
+      );
+      expect((evaluate('ubwoko(ubusa)').result as { name: string }).name).toBe(
+        'ubusa',
+      );
+      expect((evaluate('ubwoko([1])').result as { name: string }).name).toBe(
+        'urutonde',
+      );
+      // User and native functions share one function type value.
       expect(
-        asString(
+        (evaluate('ubwoko(tangaza_amakuru)').result as { name: string }).name,
+      ).toBe('porogaramu_ntoya');
+      expect(
+        (
           evaluate(`
             porogaramu_ntoya f() { tanga 1 }
             ubwoko(f)
-          `).result,
-        ),
+          `).result as { name: string }
+        ).name,
       ).toBe('porogaramu_ntoya');
+      // Same type values compare equal by identity.
+      expect(asBool(evaluate('ubwoko(5) == ubwoko(10)').result)).toBe(true);
+      expect(asBool(evaluate('ubwoko(5) == ubwoko("5")').result)).toBe(false);
     });
 
-    test('requires an argument', () => {
-      expect(() => evaluate('ubwoko()')).toThrow(
-        'ubwoko expects at least one argument',
-      );
+    test('empty call is a syntax error (prefix operator needs an operand)', () => {
+      expect(() => evaluate('ubwoko()')).toThrow();
     });
   });
 

--- a/tests/oop.test.ts
+++ b/tests/oop.test.ts
@@ -1,0 +1,293 @@
+import { describe, test, expect, beforeEach, afterEach, vi } from 'vitest';
+import { readdirSync, readFileSync } from 'fs';
+import path from 'path';
+import * as log from '../src/lib/log';
+import Parser from '../src/parser/parser';
+import { Interpreter } from '../src/runtime/interpreter';
+import { createGlobalEnv } from '../src/runtime/globals';
+import {
+  asBool,
+  asNumber,
+  asString,
+  evaluate,
+  expectKinError,
+} from './helpers';
+import { ClassVal, InstanceVal, TypeVal } from '../src/runtime/values';
+
+const OOP_DIR = path.join(process.cwd(), 'examples', 'oop');
+
+function runOop(filename: string): void {
+  const filePath = path.join(OOP_DIR, filename);
+  const source = readFileSync(filePath, 'utf-8');
+  const parser = new Parser();
+  const ast = parser.produceAST(source);
+  const env = createGlobalEnv(filePath);
+  Interpreter.evaluate(ast, env);
+}
+
+describe('OOP examples', () => {
+  beforeEach(() => {
+    vi.spyOn(log, 'LogMessage').mockImplementation(() => undefined);
+  });
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  const files = readdirSync(OOP_DIR)
+    .filter((f) => f.endsWith('.kin'))
+    .sort();
+
+  test('discovers all oop samples', () => {
+    expect(files).toEqual(
+      expect.arrayContaining([
+        'class-basics.kin',
+        'visibility.kin',
+        'inheritance.kin',
+        'instances-and-binding.kin',
+        'types-and-ubwoko.kin',
+      ]),
+    );
+  });
+
+  test.each(files)('runs examples/oop/%s without throwing', (filename) => {
+    expect(() => runOop(filename)).not.toThrow();
+  });
+});
+
+describe('OOP runtime behavior', () => {
+  beforeEach(() => {
+    vi.spyOn(log, 'LogMessage').mockImplementation(() => undefined);
+  });
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  test('class basics: construct, methods, fields', () => {
+    const { env } = evaluate(`
+      imiterere Umuntu {
+        tegura(izina, imyaka) {
+          rusange _.izina = izina
+          rusange _.imyaka = imyaka
+        }
+        rusange porogaramu_ntoya izina_ryose() {
+          tanga _.izina
+        }
+      }
+      reka keza = rema Umuntu("Keza", 20)
+    `);
+    const keza = env.lookupVar('keza') as InstanceVal;
+    expect(keza.type).toBe('instance');
+    expect(keza.klass.name).toBe('Umuntu');
+    expect(asString(keza.fields.get('izina')!)).toBe('Keza');
+    expect(asNumber(keza.fields.get('imyaka')!)).toBe(20);
+  });
+
+  test('private field is not readable from outside', () => {
+    expectKinError(
+      `
+      imiterere Umuntu {
+        tegura(izina) {
+          bwite _.izina = izina
+        }
+      }
+      reka k = rema Umuntu("K")
+      tangaza_amakuru(k.izina)
+    `,
+      'K041',
+    );
+  });
+
+  test('bound method keeps receiver', () => {
+    const { result } = evaluate(`
+      imiterere Umuntu {
+        tegura(izina) {
+          rusange _.izina = izina
+        }
+        rusange porogaramu_ntoya get() {
+          tanga _.izina
+        }
+      }
+      reka k = rema Umuntu("Keza")
+      reka f = k.get
+      f()
+    `);
+    expect(asString(result)).toBe('Keza');
+  });
+
+  test('inheritance: method override and inherited constructor', () => {
+    const { env } = evaluate(`
+      imiterere Umuntu {
+        tegura(izina, imyaka) {
+          rusange _.izina = izina
+          rusange _.imyaka = imyaka
+        }
+        rusange porogaramu_ntoya imyaka_yose() {
+          tanga _.imyaka
+        }
+      }
+      imiterere Umwarimu ikomoka Umuntu {
+        rusange porogaramu_ntoya yigisha() {
+          tanga "ok"
+        }
+      }
+      reka m = rema Umwarimu("Keza", 28)
+    `);
+    const m = env.lookupVar('m') as InstanceVal;
+    expect(m.klass.name).toBe('Umwarimu');
+    expect(asNumber(m.fields.get('imyaka')!)).toBe(28);
+  });
+
+  test('ubwoko of instance is the class value (exact match)', () => {
+    const { result } = evaluate(`
+      imiterere Umuntu {
+        tegura(n) { rusange _.n = n }
+      }
+      imiterere Child ikomoka Umuntu {}
+      reka a = rema Umuntu(1)
+      reka b = rema Child(2)
+      reka t1 = ubwoko a == Umuntu
+      reka t2 = ubwoko b == Child
+      reka t3 = ubwoko b == Umuntu
+      reka r = t1 && t2 && !t3
+      r
+    `);
+    expect(asBool(result)).toBe(true);
+  });
+
+  test('instances compare by identity', () => {
+    expect(asBool(evaluate(`
+      imiterere C { tegura() {} }
+      reka a = rema C()
+      reka b = rema C()
+      a == b
+    `).result)).toBe(false);
+    expect(asBool(evaluate(`
+      imiterere C { tegura() {} }
+      reka a = rema C()
+      a == a
+    `).result)).toBe(true);
+  });
+
+  test('class name is a type annotation (exact class)', () => {
+    evaluate(`
+      imiterere Umuntu {
+        tegura(n) { rusange _.n = n }
+      }
+      reka k: Umuntu = rema Umuntu(1)
+    `);
+    expectKinError(
+      `
+      imiterere Umuntu {
+        tegura(n) { rusange _.n = n }
+      }
+      imiterere Child ikomoka Umuntu {}
+      reka k: Umuntu = rema Child(1)
+    `,
+      'K035',
+    );
+  });
+
+  test('plain object is not an instance type', () => {
+    expectKinError(
+      `
+      imiterere Umuntu {
+        tegura(n) { rusange _.n = n }
+      }
+      reka bag: Umuntu = { n: 1 }
+    `,
+      'K035',
+    );
+  });
+
+  test('rema then method chain', () => {
+    const { result } = evaluate(`
+      imiterere Umuntu {
+        tegura(izina) { rusange _.izina = izina }
+        rusange porogaramu_ntoya get() { tanga _.izina }
+      }
+      rema Umuntu("Keza").get()
+    `);
+    expect(asString(result)).toBe('Keza');
+  });
+
+  test('ubwoko of two classes is the same type value', () => {
+    expect(asBool(evaluate(`
+      imiterere A {}
+      imiterere B {}
+      ubwoko A == ubwoko B
+    `).result)).toBe(true);
+  });
+
+  test('leaked private bound method cannot be called outside', () => {
+    expectKinError(
+      `
+      imiterere C {
+        tegura() {}
+        bwite porogaramu_ntoya secret() { tanga 42 }
+        rusange porogaramu_ntoya leak() { tanga _.secret }
+      }
+      reka f = rema C().leak()
+      f()
+    `,
+      'K041',
+    );
+  });
+
+  test('freestanding callback cannot read private field under active method', () => {
+    expectKinError(
+      `
+      imiterere C {
+        tegura() { bwite _.s = 99 }
+        rusange porogaramu_ntoya use(fn) { tanga fn(_) }
+      }
+      porogaramu_ntoya outsider(o) { tanga o.s }
+      rema C().use(outsider)
+    `,
+      'K041',
+    );
+  });
+
+  test('nested plain function inside method cannot use ambient private access', () => {
+    expectKinError(
+      `
+      imiterere C {
+        tegura() { bwite _.s = 99 }
+        rusange porogaramu_ntoya m() {
+          porogaramu_ntoya helper() { tanga _.s }
+          tanga helper()
+        }
+      }
+      rema C().m()
+    `,
+      'K041',
+    );
+  });
+
+  test('duplicate method name is rejected', () => {
+    expectKinError(
+      `
+      imiterere A {
+        tegura() {}
+        rusange porogaramu_ntoya jya() { tanga 1 }
+        rusange porogaramu_ntoya jya() { tanga 2 }
+      }
+    `,
+      'K043',
+    );
+  });
+
+  test('child method cannot read parent private field', () => {
+    expectKinError(
+      `
+      imiterere Parent {
+        tegura() { bwite _.secret = 1 }
+      }
+      imiterere Child ikomoka Parent {
+        rusange porogaramu_ntoya peek() { tanga _.secret }
+      }
+      rema Child().peek()
+    `,
+      'K041',
+    );
+  });
+});

--- a/tests/types.test.ts
+++ b/tests/types.test.ts
@@ -186,18 +186,20 @@ describe('Type system — runtime checks', () => {
     `);
   });
 
-  test('ubwoko() still reports runtime type names in Kinyarwanda', () => {
+  test('ubwoko() returns a type value with Kinyarwanda name', () => {
     const { result } = evaluate('ubwoko(5)');
-    expect(asString(result)).toBe('umubare');
+    expect(result.type).toBe('type-val');
+    expect((result as { name: string }).name).toBe('umubare');
   });
 
-  test('ubwoko as type keyword and as function coexist', () => {
+  test('ubwoko as type keyword and as typeof operator coexist', () => {
     const { result } = evaluate(`
       ubwoko Id = umubare
       reka x: Id = 3
       ubwoko(x)
     `);
-    expect(asString(result)).toBe('umubare');
+    expect(result.type).toBe('type-val');
+    expect((result as { name: string }).name).toBe('umubare');
   });
 
   test('unknown type name is an error', () => {


### PR DESCRIPTION
## Summary

Implements Object-Oriented Programming for Kin as defined by `examples/oop/*`, integrated with the Kinyarwanda type system from #341.

Fixes #258

## Language surface

| Keyword | Role |
|---------|------|
| `imiterere` | Class declaration |
| `tegura` | Constructor |
| `rema` | Instantiate |
| `_` | Current instance |
| `rusange` / `bwite` | Public / private |
| `ikomoka` | Single inheritance |

## Behavior

- Fields only via `rusange/bwite _.name = expr` inside `tegura`
- Bound methods keep the receiver
- Private access only from the **declaring** class’s methods/constructor
- Freestanding `porogaramu_ntoya` calls **suspend** private privileges (callbacks cannot peep)
- Method lookup walks parents; child `tegura` replaces parent constructor

## Types ↔ OOP

- `ubwoko instance` returns the **class value** (exact match)
- `ubwoko 5 == ubwoko 10` uses shared TypeVal identity
- `reka x: Umuntu = rema Umuntu(...)` exact class annotation
- Plain `{…}` is `ubwoko_imiterere`, not a class instance

## Testing

- [x] All 5 `examples/oop/*.kin` programs
- [x] `npm test` (includes `tests/oop.test.ts` + examples suite)
- [x] `scripts/run-examples.sh` runs top-level and OOP examples