### PR TITLE
feat: multi-file modules (koresha / nka / emerera_gukoresha)

### DIFF
--- a/README.md
+++ b/README.md
@@ -125,6 +125,18 @@ npm run build:exe:all
   reka keza: Person = { name: "Keza", age: 20 }
   tangaza_amakuru(greet(keza))
   ```
+- Multi-file modules (`koresha` / `nka` / `emerera_gukoresha`)
+  ```Kin
+  # methods.kin
+  porogaramu_ntoya guteranya(a: umubare, b: umubare): umubare {
+    tanga a + b
+  }
+  emerera_gukoresha { guteranya }
+
+  # main.kin
+  koresha "./methods.kin" nka math
+  tangaza_amakuru(math.guteranya(2, 3))
+  ```
 - Executing system commands
   ```Kin
   sisitemu("sudo shutdown now")

--- a/docs/errors.md
+++ b/docs/errors.md
@@ -61,5 +61,8 @@ Host programs can branch on `instanceof`, `ERRNAME`, or `ERRCODE`.
 | K041 | TypeError | Cannot access private member | read `bwite` from outside | Use a public method wrapper. |
 | K042 | TypeError | Not a class (imiterere) | `rema 5()` | Pass a class value to rema. |
 | K043 | TypeError | Field already defined | duplicate field in tegura | Assign each field once in tegura. |
+| K044 | RuntimeError | Cannot import '{path}': file not found | bad koresha path | Fix the relative path to the .kin file. |
+| K045 | RuntimeError | Circular import | A koresha B koresha A | Break the import cycle. |
+| K046 | ReferenceError | Cannot export undefined name | emerera_gukoresha { missing } | Export only names defined in that module. |
 
 Messages are loaded from `src/messages/rw.json` (default) and `src/messages/en.json` (`KIN_LANG=en`).

--- a/examples/importing/constants.kin
+++ b/examples/importing/constants.kin
@@ -1,0 +1,7 @@
+# Shared constants for the multi-file import example.
+
+ntahinduka THRESHOLD: umubare = 0.05
+
+emerera_gukoresha {
+  THRESHOLD
+}

--- a/examples/importing/index.kin
+++ b/examples/importing/index.kin
@@ -1,0 +1,12 @@
+# Multi-file imports with namespace aliases (nka).
+# Run: kin run examples/importing/index.kin
+#
+# koresha loads another .kin file, evaluates it in its own environment,
+# and binds an object of that file's emerera_gukoresha exports under the alias.
+
+koresha "./methods.kin" nka arithmeticMethods
+koresha "./constants.kin" nka constants
+
+reka x: umubare = arithmeticMethods.guteranya(2, 3) + constants.THRESHOLD
+
+tangaza_amakuru(x)

--- a/examples/importing/methods.kin
+++ b/examples/importing/methods.kin
@@ -1,0 +1,24 @@
+# Shared arithmetic helpers for the multi-file import example.
+
+porogaramu_ntoya guteranya(a: umubare, b: umubare): umubare {
+  tanga a + b
+}
+
+porogaramu_ntoya gukuba(a: umubare, b: umubare): umubare {
+  tanga a * b
+}
+
+porogaramu_ntoya gukuramo(a: umubare, b: umubare): umubare {
+  tanga a - b
+}
+
+porogaramu_ntoya kugabanya(a: umubare, b: umubare): umubare {
+  tanga a / b
+}
+
+emerera_gukoresha {
+  guteranya,
+  gukuba,
+  gukuramo,
+  kugabanya
+}

--- a/examples/importing/person.kin
+++ b/examples/importing/person.kin
@@ -1,0 +1,16 @@
+# Module exporting an imiterere class (OOP + modules).
+
+imiterere Umuntu {
+  tegura(izina: ijambo, imyaka: umubare) {
+    rusange _.izina = izina
+    rusange _.imyaka = imyaka
+  }
+
+  rusange porogaramu_ntoya kwibwira() {
+    tangaza_amakuru("Nitwa ", _.izina, ", mfite imyaka ", _.imyaka)
+  }
+}
+
+emerera_gukoresha {
+  Umuntu
+}

--- a/examples/importing/with-oop.kin
+++ b/examples/importing/with-oop.kin
@@ -1,0 +1,11 @@
+# Import a module that exports a class; construct via the namespace.
+# Run: kin run examples/importing/with-oop.kin
+#
+# Exported classes are values on the namespace (people.Umuntu) and their
+# type is also registered under the bare name (Umuntu) for annotations.
+
+koresha "./person.kin" nka people
+
+reka keza: Umuntu = rema people.Umuntu("Keza", 20)
+keza.kwibwira()
+tangaza_amakuru(ubwoko keza == people.Umuntu)

--- a/grammar.bnf
+++ b/grammar.bnf
@@ -27,6 +27,8 @@ program ::= statement*
 statement ::= variableDeclaration
             | typeAliasDeclaration
             | classDeclaration
+            | importDeclaration
+            | exportDeclaration
             | functionDeclaration
             | loopStatement
             | breakStatement
@@ -68,6 +70,13 @@ methodDecl ::= ("rusange" | "bwite") "porogaramu_ntoya" identifier
 ; rema binds tighter than binary ops; (rema C(…)).method() is valid.
 remaExpression ::= "rema" memberExpression "(" argumentList? ")"
                    (memberSuffix | "(" argumentList? ")")*
+
+; Modules: import as namespace object; explicit exports.
+; Paths are relative to the importing file. Each path loads once per run.
+importDeclaration ::= "koresha" stringLiteral "nka" identifier ";"?
+exportDeclaration ::= "emerera_gukoresha" "{"
+                        (identifier ("," identifier)* ","?)?
+                      "}" ";"?
 
 functionDeclaration ::= "porogaramu_ntoya" identifier "(" parameterList? ")"
                         typeAnnotation? block
@@ -247,6 +256,7 @@ stringLiteral ::= '"' { anyCharacterExceptQuoteOrNewline } '"'
 ; gereranya  usanze  ibindi
 ; ubwoko     (type alias keyword + typeof prefix operator)
 ; imiterere  tegura  rema  rusange  bwite  ikomoka
+; koresha  nka  emerera_gukoresha
 
 ; Built-in type names:
 ; umubare  ijambo  ukuri  ubwoko_imiterere  urutonde

--- a/scripts/run-examples.sh
+++ b/scripts/run-examples.sh
@@ -19,9 +19,9 @@ failed=0
 ran=0
 
 shopt -s nullglob
-examples=(examples/*.kin examples/oop/*.kin)
+examples=(examples/*.kin examples/oop/*.kin examples/importing/*.kin)
 if [[ ${#examples[@]} -eq 0 ]]; then
-  echo "No example programs found in examples/ or examples/oop/" >&2
+  echo "No example programs found under examples/" >&2
   exit 1
 fi
 
@@ -33,6 +33,13 @@ for example in "${examples[@]}"; do
     io.kin|switch.kin)
       echo "SKIP $rel (interactive; covered by tests/examples.test.ts)"
       continue
+      ;;
+    # Library modules used only as dependencies of index.kin / with-oop.kin
+    methods.kin|constants.kin|person.kin)
+      if [[ "$rel" == importing/* ]]; then
+        echo "SKIP $rel (imported library; run via index.kin / with-oop.kin)"
+        continue
+      fi
       ;;
   esac
 

--- a/src/lexer/lexer.ts
+++ b/src/lexer/lexer.ts
@@ -223,6 +223,12 @@ class Lexer {
         return TokenType.BWITE;
       case 'ikomoka':
         return TokenType.IKOMOKA;
+      case 'koresha':
+        return TokenType.KORESHA;
+      case 'nka':
+        return TokenType.NKA;
+      case 'emerera_gukoresha':
+        return TokenType.EMERERA_GUKORESHA;
       default:
         return undefined;
     }

--- a/src/lexer/tokens.ts
+++ b/src/lexer/tokens.ts
@@ -83,6 +83,14 @@ enum TokenType {
   /** Inheritance: `imiterere Child ikomoka Parent` */
   IKOMOKA,
 
+  /* Modules */
+  /** Import: `koresha "./file.kin" nka alias` */
+  KORESHA,
+  /** Import alias keyword (English `as`) */
+  NKA,
+  /** Export list: `emerera_gukoresha { name1, name2 }` */
+  EMERERA_GUKORESHA,
+
   EOF,
 }
 

--- a/src/lib/errors.ts
+++ b/src/lib/errors.ts
@@ -74,6 +74,11 @@ export const CODE_CATEGORY: Readonly<Record<string, KinErrorName>> = {
   K042: 'TypeError',
   K043: 'TypeError',
 
+  // Modules — koresha / emerera_gukoresha
+  K044: 'RuntimeError',
+  K045: 'RuntimeError',
+  K046: 'ReferenceError',
+
   // Runtime — control flow, exit, internals
   K013: 'RuntimeError',
   K014: 'RuntimeError',

--- a/src/messages/en.json
+++ b/src/messages/en.json
@@ -41,5 +41,8 @@
   "K040": "Field '{name}' does not exist on {klass}; fields are created only in tegura",
   "K041": "Cannot access private member '{name}'",
   "K042": "'{name}' is not a class (imiterere)",
-  "K043": "Field '{name}' is already defined"
+  "K043": "Field '{name}' is already defined",
+  "K044": "Cannot import '{path}': file not found",
+  "K045": "Circular import detected for '{path}'",
+  "K046": "Cannot export '{name}': it is not defined in this module"
 }

--- a/src/messages/rw.json
+++ b/src/messages/rw.json
@@ -41,5 +41,8 @@
   "K040": "Umwanya '{name}' ntihari kuri {klass}; umwanya uremwa muri tegura gusa",
   "K041": "Ntushobora kugera kuri '{name}' (bwite)",
   "K042": "'{name}' ntabwo ari imiterere",
-  "K043": "Umwanya '{name}' usanzwe uhari"
+  "K043": "Umwanya '{name}' usanzwe uhari",
+  "K044": "Ntibishobora gukoresha '{path}': dosiye ntabwo iboneka",
+  "K045": "Import y'uruziga yabonetse kuri '{path}'",
+  "K046": "Ntushobora kohereza '{name}': ntabwo yatazwe muri iyi module"
 }

--- a/src/parser/ast.ts
+++ b/src/parser/ast.ts
@@ -13,6 +13,8 @@ export type NodeType =
   | 'TypeAliasDeclaration'
   | 'ClassDeclaration'
   | 'FieldInitStatement'
+  | 'ImportDeclaration'
+  | 'ExportDeclaration'
   | 'LoopStatement'
   | 'BreakStatement'
   | 'ContinueStatement'
@@ -198,6 +200,24 @@ export interface RemaExpr extends Expr {
   kind: 'RemaExpr';
   classExpr: Expr;
   args: Expr[];
+}
+
+/**
+ * Import a module as a namespace object:
+ * `koresha "./methods.kin" nka arithmeticMethods`
+ */
+export interface ImportDeclaration extends Stmt {
+  kind: 'ImportDeclaration';
+  path: string;
+  alias: string;
+}
+
+/**
+ * Explicit exports: `emerera_gukoresha { guteranya, THRESHOLD }`
+ */
+export interface ExportDeclaration extends Stmt {
+  kind: 'ExportDeclaration';
+  names: string[];
 }
 
 /**
@@ -396,6 +416,18 @@ export function mkRema(
   span: Span,
 ): RemaExpr {
   return { kind: 'RemaExpr', classExpr, args, span };
+}
+
+export function mkImport(
+  path: string,
+  alias: string,
+  span: Span,
+): ImportDeclaration {
+  return { kind: 'ImportDeclaration', path, alias, span };
+}
+
+export function mkExport(names: string[], span: Span): ExportDeclaration {
+  return { kind: 'ExportDeclaration', names, span };
 }
 
 export function mkNamedType(name: string, span: Span): NamedType {

--- a/src/parser/parser.ts
+++ b/src/parser/parser.ts
@@ -25,10 +25,12 @@ import {
   mkClassDecl,
   mkConditional,
   mkContinue,
+  mkExport,
   mkFieldInit,
   mkFunction,
   mkFunctionParam,
   mkIdent,
+  mkImport,
   mkLoop,
   mkMember,
   mkNamedType,
@@ -211,6 +213,8 @@ export default class Parser {
         t === TokenType.TANGA ||
         t === TokenType.UBWOKO ||
         t === TokenType.IMITERERE ||
+        t === TokenType.KORESHA ||
+        t === TokenType.EMERERA_GUKORESHA ||
         t === TokenType.CLOSE_CURLY_BRACES ||
         t === TokenType.HAGARARA ||
         t === TokenType.KOMEZA
@@ -237,6 +241,10 @@ export default class Parser {
         return this.parse_expr();
       case TokenType.IMITERERE:
         return this.parse_class_declaration();
+      case TokenType.KORESHA:
+        return this.parse_import_declaration();
+      case TokenType.EMERERA_GUKORESHA:
+        return this.parse_export_declaration();
       case TokenType.NIBA:
         return this.parse_if_statement();
       case TokenType.GERERANYA:
@@ -1126,6 +1134,50 @@ export default class Parser {
       );
     }
     return this.parse_stmt();
+  }
+
+  /**
+   * `koresha "./file.kin" nka alias`
+   * Optional trailing semicolon (as in the original samples).
+   */
+  private parse_import_declaration(): Stmt {
+    const startTok = this.eat(); // koresha
+    const pathTok = this.expect(TokenType.STRING, 'module path string');
+    this.expect(TokenType.NKA, 'nka');
+    const aliasTok = this.expect(TokenType.IDENTIFIER, 'import alias');
+    let endSpan = tokenSpan(aliasTok);
+    if (this.at().type == TokenType.SEMI_COLON) {
+      endSpan = tokenSpan(this.eat());
+    }
+    return mkImport(
+      pathTok.lexeme,
+      aliasTok.lexeme,
+      mergeSpans(tokenSpan(startTok), endSpan),
+    );
+  }
+
+  /**
+   * `emerera_gukoresha { name1, name2, ... }`
+   * Trailing comma accepted.
+   */
+  private parse_export_declaration(): Stmt {
+    const startTok = this.eat(); // emerera_gukoresha
+    this.expect(TokenType.OPEN_CURLY_BRACES, '{');
+    const names: string[] = [];
+    while (this.not_eof() && this.at().type != TokenType.CLOSE_CURLY_BRACES) {
+      const nameTok = this.expect(TokenType.IDENTIFIER, 'export name');
+      names.push(nameTok.lexeme);
+      if (this.at().type == TokenType.COMMA) {
+        this.eat();
+      } else if (this.at().type != TokenType.CLOSE_CURLY_BRACES) {
+        this.expect(TokenType.COMMA, ',');
+      }
+    }
+    const endTok = this.expect(TokenType.CLOSE_CURLY_BRACES, '}');
+    if (this.at().type == TokenType.SEMI_COLON) {
+      this.eat();
+    }
+    return mkExport(names, mergeSpans(tokenSpan(startTok), tokenSpan(endTok)));
   }
 
   private parse_class_method(

--- a/src/runtime/environment.ts
+++ b/src/runtime/environment.ts
@@ -407,6 +407,11 @@ export default class Environment {
 
     return this.parent.resolve(varname);
   }
+
+  /** Root environment of this chain (shared builtins / module cache key). */
+  public getRoot(): Environment {
+    return this.parent ? this.parent.getRoot() : this;
+  }
 }
 
 /** Method lookup: own class first, then walk parents. */

--- a/src/runtime/eval/statements.ts
+++ b/src/runtime/eval/statements.ts
@@ -8,8 +8,10 @@ import {
   ClassDeclaration,
   ConditionalStmt,
   ContinueStatement,
+  ExportDeclaration,
   FieldInitStatement,
   FunctionDeclaration,
+  ImportDeclaration,
   LoopStatement,
   Program,
   Stmt,
@@ -30,6 +32,7 @@ import {
 } from '../signals';
 import { resolveAnnotation, resolveTypeNode } from '../types';
 import { eval_class_declaration, eval_field_init } from '../oop';
+import { eval_import, registerExports } from '../modules';
 
 export default class EvalStmt {
   public static eval_program(program: Program, env: Environment): RuntimeVal {
@@ -82,6 +85,25 @@ export default class EvalStmt {
     env: Environment,
   ): RuntimeVal {
     return eval_field_init(declaration, env);
+  }
+
+  public static eval_import(
+    declaration: ImportDeclaration,
+    env: Environment,
+  ): RuntimeVal {
+    return eval_import(
+      declaration.path,
+      declaration.alias,
+      env,
+      declaration.span,
+    );
+  }
+
+  public static eval_export(
+    declaration: ExportDeclaration,
+    env: Environment,
+  ): RuntimeVal {
+    return registerExports(env, declaration.names, declaration.span);
   }
 
   public static eval_function_declaration(

--- a/src/runtime/interpreter.ts
+++ b/src/runtime/interpreter.ts
@@ -12,7 +12,9 @@ import {
   ClassDeclaration,
   ContinueStatement,
   CallExpr,
+  ExportDeclaration,
   FieldInitStatement,
+  ImportDeclaration,
   LoopStatement,
   FunctionDeclaration,
   Identifier,
@@ -140,6 +142,10 @@ export class Interpreter {
             astNode as FieldInitStatement,
             env,
           );
+        case 'ImportDeclaration':
+          return EvalStmt.eval_import(astNode as ImportDeclaration, env);
+        case 'ExportDeclaration':
+          return EvalStmt.eval_export(astNode as ExportDeclaration, env);
         case 'FunctionDeclaration':
           return EvalStmt.eval_function_declaration(
             astNode as FunctionDeclaration,

--- a/src/runtime/modules.ts
+++ b/src/runtime/modules.ts
@@ -1,0 +1,247 @@
+/*************************************************************************************************************
+ *                                              Modules (koresha)                                            *
+ *  koresha "./file.kin" nka alias  — load module, bind exports as a namespace object.                       *
+ *  emerera_gukoresha { a, b }      — mark names for export from the current module.                         *
+ *************************************************************************************************************/
+
+import { existsSync, readFileSync, statSync } from 'fs';
+import path from 'path';
+import Parser from '../parser/parser';
+import { createKinError } from '../lib/errors';
+import { Span } from '../lib/span';
+import Environment from './environment';
+import { Interpreter } from './interpreter';
+import {
+  resolveEntryFilename,
+  resolveKinPath,
+  withCurrentFile,
+} from './path-resolve';
+import {
+  MK_NULL,
+  MK_OBJECT,
+  MK_STRING,
+  ObjectVal,
+  RuntimeVal,
+} from './values';
+
+export interface ModuleRecord {
+  path: string;
+  /** Namespace object: properties are exported values. */
+  exports: ObjectVal;
+  /** Type aliases exported (if any) — available for future cross-module types. */
+  exportedTypes: Map<string, import('./types').ResolvedType>;
+}
+
+/** Cache of fully loaded modules per program root environment. */
+const modulesByRoot = new WeakMap<Environment, Map<string, ModuleRecord>>();
+
+/** Paths currently loading (cycle detection) per root. */
+const loadingByRoot = new WeakMap<Environment, Set<string>>();
+
+/**
+ * Export names registered while evaluating a module (via emerera_gukoresha).
+ * Keyed by the module environment (not root).
+ */
+const pendingExports = new WeakMap<Environment, string[]>();
+
+function moduleCache(root: Environment): Map<string, ModuleRecord> {
+  let map = modulesByRoot.get(root);
+  if (!map) {
+    map = new Map();
+    modulesByRoot.set(root, map);
+  }
+  return map;
+}
+
+function loadingSet(root: Environment): Set<string> {
+  let set = loadingByRoot.get(root);
+  if (!set) {
+    set = new Set();
+    loadingByRoot.set(root, set);
+  }
+  return set;
+}
+
+/** Mark the entry script so it is not re-loaded if koresha'd. */
+function ensureEntrySeeded(root: Environment): void {
+  const cache = moduleCache(root);
+  const entry = path.resolve(resolveEntryFilename(root));
+  try {
+    if (existsSync(entry) && statSync(entry).isFile() && !cache.has(entry)) {
+      // Entry is not a ModuleRecord unless it was loaded as a module.
+      // Only seed the loading set indirectly via loaded paths on re-import.
+    }
+  } catch {
+    // ignore
+  }
+}
+
+/**
+ * Register export names for the current module environment.
+ * Names are resolved when the module finishes loading (or immediately if
+ * called after bindings exist — we resolve at end of load for flexibility).
+ */
+export function registerExports(
+  moduleEnv: Environment,
+  names: string[],
+  span?: Span,
+): RuntimeVal {
+  const list = pendingExports.get(moduleEnv) ?? [];
+  for (const name of names) {
+    if (!list.includes(name)) list.push(name);
+  }
+  pendingExports.set(moduleEnv, list);
+  // Validate that names currently exist (samples put export after defs).
+  for (const name of names) {
+    try {
+      moduleEnv.lookupVar(name);
+    } catch {
+      // Type-only names (ubwoko aliases) live in the type map.
+      if (!moduleEnv.lookupType(name)) {
+        throw createKinError('K046', {
+          span,
+          params: { name },
+          message: `Cannot export '${name}': it is not defined in this module`,
+        });
+      }
+    }
+  }
+  return MK_NULL();
+}
+
+function collectExports(moduleEnv: Environment): {
+  values: Map<string, RuntimeVal>;
+  types: Map<string, import('./types').ResolvedType>;
+} {
+  const names = pendingExports.get(moduleEnv) ?? [];
+  const values = new Map<string, RuntimeVal>();
+  const types = new Map<string, import('./types').ResolvedType>();
+
+  for (const name of names) {
+    try {
+      values.set(name, moduleEnv.lookupVar(name));
+    } catch {
+      // value missing
+    }
+    const t = moduleEnv.lookupType(name);
+    if (t) types.set(name, t);
+    if (!values.has(name) && !types.has(name)) {
+      throw createKinError('K046', {
+        params: { name },
+        message: `Cannot export '${name}': it is not defined in this module`,
+      });
+    }
+  }
+
+  return { values, types };
+}
+
+/**
+ * Load a module (or return cached), evaluate it, and return its export object.
+ */
+export function loadModule(
+  importerEnv: Environment,
+  requestedPath: string,
+  span?: Span,
+): ModuleRecord {
+  const root = importerEnv.getRoot();
+  ensureEntrySeeded(root);
+
+  const absolute = path.resolve(resolveKinPath(importerEnv, requestedPath));
+  const cache = moduleCache(root);
+
+  if (cache.has(absolute)) {
+    return cache.get(absolute)!;
+  }
+
+  const loading = loadingSet(root);
+  if (loading.has(absolute)) {
+    throw createKinError('K045', {
+      span,
+      params: { path: requestedPath },
+      message: `Circular import detected for '${requestedPath}'`,
+    });
+  }
+
+  if (!existsSync(absolute) || !statSync(absolute).isFile()) {
+    throw createKinError('K044', {
+      span,
+      params: { path: requestedPath },
+      message: `Cannot import '${requestedPath}': file not found`,
+    });
+  }
+
+  let source: string;
+  try {
+    source = readFileSync(absolute, 'utf-8');
+  } catch {
+    throw createKinError('K044', {
+      span,
+      params: { path: requestedPath },
+      message: `Cannot import '${requestedPath}': file not readable`,
+    });
+  }
+
+  loading.add(absolute);
+
+  // Fresh module environment: inherits builtins from root, own bindings stay local.
+  const moduleEnv = new Environment(root);
+  moduleEnv.declareVar('filename', MK_STRING(absolute), true);
+  pendingExports.set(moduleEnv, []);
+
+  try {
+    const parser = new Parser();
+    const program = parser.produceAST(source);
+
+    withCurrentFile(absolute, () => {
+      Interpreter.evaluate(program, moduleEnv);
+    });
+
+    const { values, types } = collectExports(moduleEnv);
+    const exportsObj = MK_OBJECT(values);
+    const record: ModuleRecord = {
+      path: absolute,
+      exports: exportsObj,
+      exportedTypes: types,
+    };
+    cache.set(absolute, record);
+    return record;
+  } finally {
+    loading.delete(absolute);
+  }
+}
+
+/**
+ * Evaluate `koresha "path" nka alias`: load module and bind the export object.
+ */
+export function eval_import(
+  pathStr: string,
+  alias: string,
+  env: Environment,
+  span?: Span,
+): RuntimeVal {
+  const mod = loadModule(env, pathStr, span);
+  // Bind namespace object as a constant in the importer.
+  env.declareVar(alias, mod.exports, true);
+
+  // Register exported type aliases under the bare export names only when the
+  // importer does a namespace import — types stay accessed via values when
+  // they are classes. Pure type aliases on the module are re-registered under
+  // `alias` prefix is not valid in type syntax, so we register class types
+  // that have a matching ClassVal export under the local alias... skipped.
+  // Class exports work as values: rema alias.ClassName(...)
+  // Also register types from the module that match export names into the
+  // importer type env under the same names if not already present — allows
+  // `reka x: Person` after importing a module that exported Person class.
+  for (const [name, type] of mod.exportedTypes) {
+    if (!env.lookupType(name)) {
+      try {
+        env.declareType(name, type);
+      } catch {
+        // already defined locally — leave existing
+      }
+    }
+  }
+
+  return mod.exports;
+}

--- a/src/runtime/path-resolve.ts
+++ b/src/runtime/path-resolve.ts
@@ -1,0 +1,54 @@
+/*************************************************************************************************************
+ *                                              Path resolution                                              *
+ *  Resolve script-relative paths for KIN_INYANDIKO and koresha. Nested modules push the current file so     *
+ *  relative paths resolve against the file being evaluated, not only the entry script.                      *
+ *************************************************************************************************************/
+
+import path from 'path';
+import Environment from './environment';
+import { StringVal } from './values';
+
+/**
+ * Absolute paths of files currently being evaluated (entry + nested modules).
+ * Process-global by design: Kin evaluation is single-threaded.
+ */
+const currentFileStack: string[] = [];
+
+/**
+ * Resolve a path relative to the file currently being evaluated.
+ * Falls back to the `filename` binding when the stack is empty.
+ */
+export function resolveKinPath(
+  env: Environment,
+  relativeOrAbsolute: string,
+): string {
+  if (path.isAbsolute(relativeOrAbsolute)) {
+    return path.normalize(relativeOrAbsolute);
+  }
+
+  const baseFile =
+    currentFileStack[currentFileStack.length - 1] ?? resolveEntryFilename(env);
+
+  return path.resolve(path.dirname(baseFile), relativeOrAbsolute);
+}
+
+/** Normalize the entry `filename` binding to an absolute path. */
+export function resolveEntryFilename(env: Environment): string {
+  const raw = (env.lookupVar('filename') as StringVal).value;
+  if (path.isAbsolute(raw)) {
+    return path.normalize(raw);
+  }
+  return path.resolve(process.cwd(), raw);
+}
+
+/**
+ * Run `fn` with `absolutePath` as the current file for relative path resolution.
+ */
+export function withCurrentFile<T>(absolutePath: string, fn: () => T): T {
+  currentFileStack.push(path.normalize(absolutePath));
+  try {
+    return fn();
+  } finally {
+    currentFileStack.pop();
+  }
+}

--- a/tests/imports.test.ts
+++ b/tests/imports.test.ts
@@ -1,0 +1,216 @@
+import { describe, test, expect, beforeEach, afterEach, vi } from 'vitest';
+import path from 'path';
+import { writeFileSync, mkdtempSync, rmSync } from 'fs';
+import os from 'os';
+import * as log from '../src/lib/log';
+import Parser from '../src/parser/parser';
+import { Interpreter } from '../src/runtime/interpreter';
+import { createGlobalEnv } from '../src/runtime/globals';
+import {
+  asNumber,
+  asString,
+  evaluate,
+  expectKinError,
+} from './helpers';
+import { ObjectVal } from '../src/runtime/values';
+
+function runFile(absolutePath: string): void {
+  const source = require('fs').readFileSync(absolutePath, 'utf-8');
+  const parser = new Parser();
+  const ast = parser.produceAST(source);
+  const env = createGlobalEnv(absolutePath);
+  Interpreter.evaluate(ast, env);
+}
+
+describe('examples/importing', () => {
+  beforeEach(() => {
+    vi.spyOn(log, 'LogMessage').mockImplementation(() => undefined);
+  });
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  test('runs index.kin (namespace imports)', () => {
+    const file = path.join(process.cwd(), 'examples/importing/index.kin');
+    expect(() => runFile(file)).not.toThrow();
+  });
+
+  test('runs with-oop.kin (imported class)', () => {
+    const file = path.join(process.cwd(), 'examples/importing/with-oop.kin');
+    expect(() => runFile(file)).not.toThrow();
+  });
+});
+
+describe('koresha / emerera_gukoresha', () => {
+  let tmp: string;
+
+  beforeEach(() => {
+    tmp = mkdtempSync(path.join(os.tmpdir(), 'kin-import-'));
+    vi.spyOn(log, 'LogMessage').mockImplementation(() => undefined);
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+    rmSync(tmp, { recursive: true, force: true });
+  });
+
+  function write(name: string, body: string): string {
+    const p = path.join(tmp, name);
+    writeFileSync(p, body, 'utf-8');
+    return p;
+  }
+
+  test('imports exports as a namespace object', () => {
+    write(
+      'lib.kin',
+      `
+      porogaramu_ntoya add(a: umubare, b: umubare): umubare { tanga a + b }
+      ntahinduka PI: umubare = 3
+      emerera_gukoresha { add, PI }
+    `,
+    );
+    const main2 = write(
+      'main2.kin',
+      `
+      koresha "./lib.kin" nka lib
+      reka x: umubare = lib.add(2, lib.PI)
+    `,
+    );
+    const source = require('fs').readFileSync(main2, 'utf-8');
+    const env = createGlobalEnv(main2);
+    Interpreter.evaluate(new Parser().produceAST(source), env);
+    expect(asNumber(env.lookupVar('x'))).toBe(5);
+    const lib = env.lookupVar('lib') as ObjectVal;
+    expect(lib.type).toBe('object');
+    expect(asNumber(lib.properties.get('PI')!)).toBe(3);
+  });
+
+  test('optional semicolon after koresha', () => {
+    write('u.kin', `reka v = 1\nemerera_gukoresha { v }`);
+    const main = write(
+      'm.kin',
+      `koresha "./u.kin" nka u;\ntangaza_amakuru(u.v)`,
+    );
+    expect(() => runFile(main)).not.toThrow();
+  });
+
+  test('missing file is K044', () => {
+    const main = write(
+      'm.kin',
+      `koresha "./nope.kin" nka x`,
+    );
+    try {
+      runFile(main);
+      throw new Error('expected throw');
+    } catch (e: any) {
+      expect(e.code).toBe('K044');
+    }
+  });
+
+  test('circular import is K045', () => {
+    write(
+      'a.kin',
+      `koresha "./b.kin" nka b\nemerera_gukoresha { }`,
+    );
+    write(
+      'b.kin',
+      `koresha "./a.kin" nka a\nemerera_gukoresha { }`,
+    );
+    // empty export list - still loads
+    write(
+      'a2.kin',
+      `
+      koresha "./b2.kin" nka b
+      reka fromA = 1
+      emerera_gukoresha { fromA }
+    `,
+    );
+    write(
+      'b2.kin',
+      `
+      koresha "./a2.kin" nka a
+      reka fromB = 2
+      emerera_gukoresha { fromB }
+    `,
+    );
+    try {
+      runFile(path.join(tmp, 'a2.kin'));
+      throw new Error('expected circular import error');
+    } catch (e: any) {
+      expect(e.code).toBe('K045');
+    }
+  });
+
+  test('export of undefined name is K046', () => {
+    const f = write(
+      'bad.kin',
+      `emerera_gukoresha { missing }`,
+    );
+    try {
+      runFile(f);
+      throw new Error('expected throw');
+    } catch (e: any) {
+      expect(e.code).toBe('K046');
+    }
+  });
+
+  test('second import of same path reuses cache', () => {
+    write(
+      'once.kin',
+      `
+      reka counter = 0
+      counter = counter + 1
+      emerera_gukoresha { counter }
+    `,
+    );
+    const main = write(
+      'main.kin',
+      `
+      koresha "./once.kin" nka a
+      koresha "./once.kin" nka b
+      reka same = a.counter == b.counter
+    `,
+    );
+    const source = require('fs').readFileSync(main, 'utf-8');
+    const env = createGlobalEnv(main);
+    Interpreter.evaluate(new Parser().produceAST(source), env);
+    // Both aliases see counter === 1 (module body runs once)
+    expect(asNumber((env.lookupVar('a') as ObjectVal).properties.get('counter')!)).toBe(1);
+    expect(asNumber((env.lookupVar('b') as ObjectVal).properties.get('counter')!)).toBe(1);
+  });
+
+  test('imported class works with rema and ubwoko', () => {
+    write(
+      'cls.kin',
+      `
+      imiterere Box {
+        tegura(n: umubare) { rusange _.n = n }
+        rusange porogaramu_ntoya get(): umubare { tanga _.n }
+      }
+      emerera_gukoresha { Box }
+    `,
+    );
+    const main = write(
+      'main.kin',
+      `
+      koresha "./cls.kin" nka m
+      reka b: Box = rema m.Box(7)
+      reka ok = ubwoko b == m.Box
+      reka n = b.get()
+    `,
+    );
+    const source = require('fs').readFileSync(main, 'utf-8');
+    const env = createGlobalEnv(main);
+    Interpreter.evaluate(new Parser().produceAST(source), env);
+    expect(asNumber(env.lookupVar('n'))).toBe(7);
+  });
+
+  test('parser accepts koresha ... nka and emerera_gukoresha', () => {
+    const ast = new Parser().produceAST(`
+      koresha "./x.kin" nka x
+      emerera_gukoresha { a, b }
+    `);
+    expect(ast.body[0].kind).toBe('ImportDeclaration');
+    expect(ast.body[1].kind).toBe('ExportDeclaration');
+  });
+});


### PR DESCRIPTION
## Summary

Multi-file programs with explicit exports and namespace imports, based on the design samples (fork commit with `as` → **`nka`**).

Related to #169

## Syntax

```kin
# lib.kin
porogaramu_ntoya guteranya(a: umubare, b: umubare): umubare { tanga a + b }
emerera_gukoresha { guteranya }

# main.kin
koresha "./lib.kin" nka math
tangaza_amakuru(math.guteranya(2, 3))
```

## Behavior

- Only `emerera_gukoresha` names are exported
- Import binds a constant namespace object under the alias
- Paths relative to the importing file; load-once cache
- K044 missing file, K045 circular import, K046 bad export
- Works with types and OOP (`rema people.Umuntu(...)`)

## Testing

- [x] `tests/imports.test.ts`
- [x] `examples/importing/index.kin` and `with-oop.kin`
- [x] Full test suite

## Note

Depends on OOP/types already on main or stacked after #342. If #342 is not merged, base this PR on that branch.